### PR TITLE
Validated Fields of Assignment Creation Form

### DIFF
--- a/frontend/src/pages/instructor/assignments/CreateAssignment.js
+++ b/frontend/src/pages/instructor/assignments/CreateAssignment.js
@@ -125,6 +125,7 @@ export default ({
                   label="ASSIGNMENT NAME"
                   name="name"
                   validateStatus={nameValidationStatus}
+                  rules={[{ required: true, message: "Please enter a name" }]}
                 >
                   <Input placeholder="Name your assignment" />
                 </Form.Item>
@@ -151,6 +152,10 @@ export default ({
                     <Form.Item
                       label="AUTOGRADER POINTS"
                       name="autograderPoints"
+                      rules={[
+                        { required: true, message: "Please enter a point value" },
+                        { pattern: /^\d+$/, message: "Only numeric values allowed" },
+                      ]}
                     >
                       <Input />
                     </Form.Item>
@@ -179,12 +184,13 @@ export default ({
                           <Form.Item
                             label="RELEASE DATE (CDT)"
                             name="releaseDate"
+                            rules={[{ required: true, message: "Please select a release date" }]}
                           >
                             <DatePicker showTime style={{ width: "100%" }} />
                           </Form.Item>
                         </Col>
                         <Col span={24} md={12}>
-                          <Form.Item label="DUE DATE (CDT)" name="dueDate">
+                          <Form.Item label="DUE DATE (CDT)" name="dueDate" rules={[{ required: true, message: "Please select a due date" }]}>
                             <DatePicker showTime style={{ width: "100%" }} />
                           </Form.Item>
                         </Col>
@@ -199,7 +205,18 @@ export default ({
                         <Col span={24} md={12}>
                           <Form.Item
                             label="LATE DUE DATE (CDT)"
+                            dependencies={["dueDate"]}
                             name="lateDueDate"
+                            rules={[
+                              ({ getFieldValue }) => ({
+                                validator(_, value) {
+                                  if (!value || getFieldValue("dueDate") < value) {
+                                    return Promise.resolve();
+                                  }
+                                  return Promise.reject(new Error("Late due date must be after due date"));
+                                },
+                              }),
+                            ]}
                           >
                             <DatePicker showTime style={{ width: "100%" }} />
                           </Form.Item>
@@ -246,7 +263,12 @@ export default ({
                     >
                       <Checkbox>Enable Group Submission</Checkbox>
                     </Form.Item>
-                    <Form.Item label="LIMIT GROUP SIZE" name="limitGroupSize">
+                    <Form.Item label="LIMIT GROUP SIZE" 
+                    name="limitGroupSize" 
+                    rules={[
+                      { required: false},
+                      { pattern: /^\d+$/, message: "Only numeric values allowed" },
+                    ]}>
                       <Input />
                     </Form.Item>
                   </>
@@ -260,7 +282,10 @@ export default ({
                     >
                       <Checkbox>Enable Leaderboard</Checkbox>
                     </Form.Item>
-                    <Form.Item label="DEFAULT # OF ENTRIES" name="leaderBoard">
+                    <Form.Item label="DEFAULT # OF ENTRIES" name="leaderBoard" rules={[
+                      { required: false},
+                      { pattern: /^\d+$/, message: "Only numeric values allowed" },
+                    ]}>
                       <Input />
                     </Form.Item>
                   </>


### PR DESCRIPTION
Fixes #131, adding form validation to the form used by instructors to create assignments.

Made "Release Date" and "Due Date" fields required. 
Added validation to make sure "Late Due Date" is after "Due Date."
Added validation to make sure "Autograder Points," "Group Size," and "Default # of Entries" fields only allow numbers.
Added helpful messages to all validation requirements.
