### PR TITLE
Created autograder timeout feature #126

### DIFF
--- a/backend/api/create_tables.sql
+++ b/backend/api/create_tables.sql
@@ -62,6 +62,7 @@ CREATE TABLE assignments (
     autograder_file bytea,
     -- new container_id column
     container_id varchar(),
+    autograder_timeout integer DEFAULT 300,
     FOREIGN KEY (course_id) REFERENCES courses (id)
 );
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -48,6 +48,7 @@ class Assignment(db.Model):
     published_date = db.Column(TIMESTAMP, nullable=True)
     autograder_file = db.Column(LargeBinary, nullable=True)
     container_id = db.Column(db.String)
+    autograder_timeout = db.Column(db.Integer, default=300)
 
 class Submission(db.Model):
     __tablename__ = "submissions"

--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -134,7 +134,7 @@ def upload_submission():
             timeout=autograder_timeout)
     except subprocess.TimeoutExpired:
         os.chdir(current_dir)
-        raise ServerTimeoutError("Autograder execution timed out")
+        raise ServerTimeoutError("Autograder execution timed out. Submitted program took too long to run.")
 
     if exec_proc.returncode != 0:
         os.chdir(current_dir)

--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -88,7 +88,7 @@ def upload_submission():
     assignment_id = request.form.get("assignment_id")
     student_id = request.form.get("student_id")
     if not assignment_id or not student_id or not file.filename:
-        raise BadRequestError("Missing required parameters or file")
+        raise BadRequestError("Missing required fields")
 
     filename = secure_filename(file.filename)
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -106,7 +106,8 @@ def upload_submission():
             elif os.path.isdir(file_path):
                 shutil.rmtree(file_path)
         except Exception as e:
-            raise InternalProcessingError("Failed to delete {file_path}. Reason: {e}")
+            print(f"Failed to delete {file_path}. Reason: {e}")
+            raise InternalProcessingError("Failed to grade submission")
     file_path = os.path.join(submissions_dir, filename)
 
     file.save(file_path)
@@ -117,14 +118,16 @@ def upload_submission():
     start_proc = subprocess.run(f"docker start {container_name}".split(), capture_output=True)
     if start_proc.returncode != 0:
         os.chdir(current_dir)
-        raise InternalProcessingError(f"error: Failed to start Docker container, details: {start_proc.stderr.decode()}")
+        print(f"error: Failed to start Docker container, details: {start_proc.stderr.decode()}")
+        raise InternalProcessingError("Failed to grade submission")
 
 
     # copy the file into the correct place
     copy_proc = subprocess.run(f"docker cp {file_path} {container_name}:/autograder/submission/".split(), capture_output=True)
     if copy_proc.returncode != 0:
         os.chdir(current_dir)
-        raise InternalProcessingError(f"error: Failed to start Docker container, details: {copy_proc.stderr.decode()}")
+        print(f"error: Failed to start Docker container, details: {copy_proc.stderr.decode()}")
+        raise InternalProcessingError("Failed to grade submission")
 
 
     try:
@@ -134,16 +137,18 @@ def upload_submission():
             timeout=autograder_timeout)
     except subprocess.TimeoutExpired:
         os.chdir(current_dir)
-        raise ServerTimeoutError("Autograder execution timed out. Submitted program took too long to run.")
+        raise ServerTimeoutError("Submitted program took too long to run")
 
     if exec_proc.returncode != 0:
         os.chdir(current_dir)
-        raise InternalProcessingError(f"error: Failed to start Docker container, details: {exec_proc.stderr.decode()}")
+        print(f"error: Failed to start Docker container, details: {exec_proc.stderr.decode()}")
+        raise InternalProcessingError("Failed to grade submission")
 
     cat_proc = subprocess.run(f"docker exec {container_name} cat /autograder/results/results.json".split(), capture_output=True)
     if cat_proc.returncode != 0:
         os.chdir(current_dir)
-        raise InternalProcessingError(f"error: Failed to start Docker container, details: {cat_proc.stderr.decode()}")
+        print(f"error: Failed to start Docker container, details: {cat_proc.stderr.decode()}")
+        raise InternalProcessingError("Failed to grade submission")
 
     results_json_content = cat_proc.stdout.decode()
     host_results_json_path = os.path.join(results_dir, 'results.json')
@@ -178,12 +183,14 @@ def upload_submission():
     # Remove the contents of the submission directory inside the Docker container
     clear_dir_proc = subprocess.run(f"docker exec {container_name} rm -rf /autograder/submission/{filename}".split(), capture_output=True)
     if clear_dir_proc.returncode != 0:
-        raise InternalProcessingError(f"error: Failed to start Docker container, details: {clear_dir_proc.stderr.decode()}")
+        print(f"error: Failed to start Docker container, details: {clear_dir_proc.stderr.decode()}")
+        raise InternalProcessingError("Failed to grade submission")
 
     # need to remove this file fropm teh source folder if it exists there
     clear_dir_proc2 = subprocess.run(f"docker exec {container_name} rm -f /autograder/source/{filename}".split(),capture_output=True)
     if clear_dir_proc2.returncode != 0:
-        raise InternalProcessingError(f"error: Failed to start Docker container, details: {clear_dir_proc2.stderr.decode()}")
+        print(f"error: Failed to start Docker container, details: {clear_dir_proc2.stderr.decode()}")
+        raise InternalProcessingError("Failed to grade submission")
 
     subprocess.run(f"docker stop {container_name}".split(), capture_output=True)
     # subprocess.run(f"docker rm {container_name}".split(), capture_output=True)

--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -9,6 +9,7 @@ from flask_cors import cross_origin
 from api import db
 from api.models import Assignment, Submission, User, Enrollment, TestCaseResult, TestCase
 from api.schemas import AssignmentSchema, SubmissionSchema, UserSchema, EnrollmentSchema
+from util.errors import BadRequestError, InternalProcessingError, ConflictError, NotFoundError, ForbiddenError, ServerTimeoutError
 from datetime import datetime, timezone
 import subprocess
 import os
@@ -82,12 +83,12 @@ def get_submissions():
 @cross_origin()
 def upload_submission():
     if "file" not in request.files:
-        return jsonify({"error": "No file part"}), 400
+        raise BadRequestError("No file part")
     file = request.files["file"]
     assignment_id = request.form.get("assignment_id")
     student_id = request.form.get("student_id")
     if not assignment_id or not student_id or not file.filename:
-        return jsonify({"error": "Missing required parameters or file"}), 400
+        raise BadRequestError("Missing required parameters or file")
 
     filename = secure_filename(file.filename)
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -105,34 +106,44 @@ def upload_submission():
             elif os.path.isdir(file_path):
                 shutil.rmtree(file_path)
         except Exception as e:
-            return jsonify({"error": f"Failed to delete {file_path}. Reason: {e}"}), 500
+            raise InternalProcessingError("Failed to delete {file_path}. Reason: {e}")
     file_path = os.path.join(submissions_dir, filename)
 
     file.save(file_path)
 
     assignment = db.session.query(Assignment).filter_by(id=assignment_id).first()
     container_name = assignment.container_id
-
+    autograder_timeout = assignment.autograder_timeout
     start_proc = subprocess.run(f"docker start {container_name}".split(), capture_output=True)
     if start_proc.returncode != 0:
         os.chdir(current_dir)
-        return jsonify({"error": "Failed to start Docker container", "details": start_proc.stderr.decode()}), 500
+        raise InternalProcessingError(f"error: Failed to start Docker container, details: {start_proc.stderr.decode()}")
+
 
     # copy the file into the correct place
     copy_proc = subprocess.run(f"docker cp {file_path} {container_name}:/autograder/submission/".split(), capture_output=True)
     if copy_proc.returncode != 0:
         os.chdir(current_dir)
-        return jsonify({"error": "Failed to copy file to Docker container", "details": copy_proc.stderr.decode()}), 500
+        raise InternalProcessingError(f"error: Failed to start Docker container, details: {copy_proc.stderr.decode()}")
 
-    exec_proc = subprocess.run(f"docker exec {container_name} /bin/bash /autograder/source/run_autograder".split(), capture_output=True)
+
+    try:
+        exec_proc = subprocess.run(
+            f"docker exec {container_name} /bin/bash /autograder/source/run_autograder".split(), 
+            capture_output=True, 
+            timeout=autograder_timeout)
+    except subprocess.TimeoutExpired:
+        os.chdir(current_dir)
+        raise ServerTimeoutError("Autograder execution timed out")
+
     if exec_proc.returncode != 0:
         os.chdir(current_dir)
-        return jsonify({"error": "Autograder execution failed", "details": exec_proc.stderr.decode()}), 500
+        raise InternalProcessingError(f"error: Failed to start Docker container, details: {exec_proc.stderr.decode()}")
 
     cat_proc = subprocess.run(f"docker exec {container_name} cat /autograder/results/results.json".split(), capture_output=True)
     if cat_proc.returncode != 0:
         os.chdir(current_dir)
-        return jsonify({"error": "Failed to read results.json", "details": cat_proc.stderr.decode()}), 500
+        raise InternalProcessingError(f"error: Failed to start Docker container, details: {cat_proc.stderr.decode()}")
 
     results_json_content = cat_proc.stdout.decode()
     host_results_json_path = os.path.join(results_dir, 'results.json')
@@ -167,12 +178,12 @@ def upload_submission():
     # Remove the contents of the submission directory inside the Docker container
     clear_dir_proc = subprocess.run(f"docker exec {container_name} rm -rf /autograder/submission/{filename}".split(), capture_output=True)
     if clear_dir_proc.returncode != 0:
-        return jsonify({"error": "Failed to clear submission directory in Docker container", "details": clear_dir_proc.stderr.decode()}), 500
+        raise InternalProcessingError(f"error: Failed to start Docker container, details: {clear_dir_proc.stderr.decode()}")
 
     # need to remove this file fropm teh source folder if it exists there
     clear_dir_proc2 = subprocess.run(f"docker exec {container_name} rm -f /autograder/source/{filename}".split(),capture_output=True)
     if clear_dir_proc2.returncode != 0:
-        return jsonify({"error": "Failed to clear submission directory in Docker container", "details": clear_dir_proc.stderr.decode()}), 500
+        raise InternalProcessingError(f"error: Failed to start Docker container, details: {clear_dir_proc2.stderr.decode()}")
 
     subprocess.run(f"docker stop {container_name}".split(), capture_output=True)
     # subprocess.run(f"docker rm {container_name}".split(), capture_output=True)
@@ -191,9 +202,10 @@ def upload_submission():
 def upload_assignment_autograder():
     # Validate input file and parameters
     if "file" not in request.files:
-        return jsonify({"error": "No file part"}), 400
+        return BadRequestError("No file part")
     file = request.files["file"]
     assignment_id = request.form.get("assignment_id")
+    autograder_timeout = request.form.get("autograder_timeout")
     if not assignment_id or not file.filename:
         return jsonify({"error": "Missing assignment ID or no selected file"}), 400
 
@@ -289,8 +301,9 @@ def upload_assignment_autograder():
     os.chdir(current_dir)
     subprocess.run(f"docker stop {container_name}".split(), capture_output=True)
 
-    # Update the assignment record with the new container ID
+    # Update the assignment record with the new container ID and autograder timeout
     assignment.container_id = container_name
+    assignment.autograder_timeout = autograder_timeout
     db.session.commit()
 
     return jsonify({"message": "Autograder uploaded and Docker image generated successfully", "image_name": f"autograder-{assignment_id}"}), 200

--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -136,6 +136,7 @@ def upload_submission():
             capture_output=True, 
             timeout=autograder_timeout)
     except subprocess.TimeoutExpired:
+        subprocess.run(f"docker stop {container_name}".split(), capture_output=True)
         os.chdir(current_dir)
         raise ServerTimeoutError("Submitted program took too long to run")
 

--- a/backend/util/errors.py
+++ b/backend/util/errors.py
@@ -10,6 +10,11 @@ class InternalProcessingError(Exception):
     def __init__(self, message="Internal processing error"):
         super().__init__(message)
 
+class ServerTimeoutError(Exception):
+    status_code = 504
+    def __init__(self, message="Server timeout error"):
+        super().__init__(message)
+
 class ConflictError(Exception):
     status_code = 409
     def __init__(self, message="Conflict error"):
@@ -33,6 +38,10 @@ def register_error_handlers(app):
 
     @app.errorhandler(InternalProcessingError)
     def handle_file_processing_error(error):
+        return jsonify({"message": str(error)}), error.status_code
+    
+    @app.errorhandler(ServerTimeoutError)
+    def handle_server_timeout_error(error):
         return jsonify({"message": str(error)}), error.status_code
     
     @app.errorhandler(ConflictError)

--- a/frontend/src/components/UploadModal.js
+++ b/frontend/src/components/UploadModal.js
@@ -4,6 +4,8 @@ import { useState, useContext, useEffect } from "react";
 import { GlobalContext } from "../App";
 import { useNavigate } from "react-router-dom";
 import LoadingOverlay from './LoadingOverlay'; // Import the LoadingOverlay component
+import { uploadSubmission } from "../services/submission";
+
 // changes made for resubmit functionality
 /**
  * file upload windows modal
@@ -133,25 +135,13 @@ export default function UploadModal({
       formData.append('assignment_id', assignmentID);
       
       setLoading(true); // Show loading overlay
-      const response = await fetch(process.env.REACT_APP_API_URL + "/upload_submission", {
-        method: "POST",
-        body: formData,
-      });
-
-
-      if (!response.ok) {
-        throw new Error("Network response was not ok");
-      }
-
-
+      const response = await uploadSubmission(formData)
       const responseData = await response.json();
-      console.log(responseData);
+
       // Proceed to results page after successful upload
-      console.log(responseData);
       navigateToResults(responseData.submissionID);
     } catch (error) {
       console.error("Error uploading file:", error);
-      message.error("Failed to upload file. Please try again.");
     }
     finally {
       setLoading(false); // Hide loading overlay

--- a/frontend/src/components/UploadModal.js
+++ b/frontend/src/components/UploadModal.js
@@ -4,7 +4,7 @@ import { useState, useContext, useEffect } from "react";
 import { GlobalContext } from "../App";
 import { useNavigate } from "react-router-dom";
 import LoadingOverlay from './LoadingOverlay'; // Import the LoadingOverlay component
-import { uploadSubmission } from "../services/submission";
+import { uploadSubmission } from "../services/assignmentResult";
 
 // changes made for resubmit functionality
 /**

--- a/frontend/src/pages/configureAutograder/index.js
+++ b/frontend/src/pages/configureAutograder/index.js
@@ -51,11 +51,15 @@ export default () => {
           <Form
             layout='vertical'
             form={form}
+            initialValues={{ autograderTimeout: "300" }}
             onFinish={values => {
+              console.log("Form Values:", values);
               setSaveLoading(true);
               const formData = new FormData();
               formData.append("assignment_id", assignmentId);
               formData.append("file", values.uploadFile?.file);
+              formData.append("autograder_timeout", values.autograderTimeout);
+              console.log("HERE" + values.autograderTimeout);
               uploadAssignmentAutograder(formData)
                 .then(() => {
                   message.success("Operation successful");
@@ -82,7 +86,7 @@ export default () => {
               {({ getFieldValue }) =>
                 getFieldValue("operation") !== "1" ? (
                   <>
-                    <Form.Item label='AUTOGRADER'>
+                    <Form.Item label='UPLOAD AUTOGRADER'>
                       <Space>
                         <Form.Item name='fileName' noStyle>
                           <Input
@@ -107,6 +111,15 @@ export default () => {
                         </Form.Item>
                       </Space>
                     </Form.Item>
+                    <Form.Item label="AUTOGRADER TIMEOUT" name="autograderTimeout">
+                      <Select defaultValue="300" style={{ width: 200 }}>
+                        <Select.Option value="300">5 minutes</Select.Option>
+                        <Select.Option value="600">10 minutes</Select.Option>
+                        <Select.Option value="1200">20 minutes</Select.Option>
+                        <Select.Option value="1800">30 minutes</Select.Option>
+                        <Select.Option value="2400">40 minutes</Select.Option>
+                      </Select>
+                    </Form.Item>
                     <Form.Item noStyle>
                       <Row gutter={30} style={{ width: "700px" }}>
                         <Col span={8}>
@@ -121,7 +134,7 @@ export default () => {
                         </Col>
                         <Col span={8}>
                           <Form.Item
-                            label='BASE IMAGE VESION'
+                            label='BASE IMAGE VERSION'
                             name='baseImageVersion'
                           >
                             <Select

--- a/frontend/src/pages/configureAutograder/index.js
+++ b/frontend/src/pages/configureAutograder/index.js
@@ -53,13 +53,11 @@ export default () => {
             form={form}
             initialValues={{ autograderTimeout: "300" }}
             onFinish={values => {
-              console.log("Form Values:", values);
               setSaveLoading(true);
               const formData = new FormData();
               formData.append("assignment_id", assignmentId);
               formData.append("file", values.uploadFile?.file);
               formData.append("autograder_timeout", values.autograderTimeout);
-              console.log("HERE" + values.autograderTimeout);
               uploadAssignmentAutograder(formData)
                 .then(() => {
                   message.success("Operation successful");

--- a/frontend/src/services/submission.js
+++ b/frontend/src/services/submission.js
@@ -1,0 +1,5 @@
+import service from ".";
+
+export async function uploadSubmission(params) {
+  return service("upload_submission", params, "post");
+}

--- a/frontend/src/services/submission.js
+++ b/frontend/src/services/submission.js
@@ -1,5 +1,0 @@
-import service from ".";
-
-export async function uploadSubmission(params) {
-  return service("upload_submission", params, "post");
-}


### PR DESCRIPTION
**Backend changes:**

- Added autograder_timeout field to submission DB entries
- In the /upload_submission endpoint, added timeout option so that docker process stops running if this time is exceeded
- Added new timeout error for error code 405
- Refactored /upload_submission endpoint to use the new error system

**Frontend changes:**
- On teachers view, added new autograder timeout option in the autograder configuration screen.
![image](https://github.com/user-attachments/assets/1a89b565-12fe-4eda-a21a-63a0e03910d3)

- On student's view, if their submission times out, this error is displayed.
![image](https://github.com/user-attachments/assets/564611bd-cc5e-416f-84ae-24cc71050ac1)