### PR TITLE
clean up course block styles

### DIFF
--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -21,29 +21,27 @@ export default function Dashboard() {
   const addCourseButtonStyle = {
     border: "1px dashed green",
     width: "230px",
-    height: "125px",
+    height: "138px",
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
     color: "green",
-    fontSize: "bold",
+    fontWeight: "bold", 
+    fontSize: "16px", 
     cursor: "pointer",
     boxSizing: "border-box",
-    padding: "10px",
-    margin: "0 10px 20px 0",
-    flex: "0 0 auto",
-  };
-
-  const courseContainerStyle = {
-    paddingTop: "30px",
+    flexShrink: 0, 
+    textAlign: "center",
   };
 
   const courseHeaderStyle = {
-    marginLeft: "25px",
     display: "flex",
     flexWrap: "wrap",
     gap: "20px",
     alignItems: "flex-start",
+    justifyContent: "flex-start", 
+    width: "100%", 
+    paddingLeft: "30px"
   };
 
   // Toggle the visibility of the course modal
@@ -56,7 +54,7 @@ export default function Dashboard() {
     const formattedCourses = {};
     coursesArray.forEach((course) => {
       const { semester, year, name, assignments, id } = course;
-      const key = `${year}${semester}`; // Assuming year and semester are always present
+      const key = `${year}${semester}`;
       if (!formattedCourses[key]) {
         formattedCourses[key] = [];
       }
@@ -122,23 +120,40 @@ export default function Dashboard() {
     <>
       <PageHeader title="Your Courses" />
       <div style={courseHeaderStyle}>
-        {Object.keys(courses)
-          .sort((a, b) => b.localeCompare(a))
-          .map((key, index) => (
-            <SemesterCourses
-              key={key}
-              yearInfo={key}
-              semesterInfo={courses[key]}
-              courseGroup={index}
-              numCourses={Object.keys(courses).length}
-            />
-          ))}
-        <div style={courseContainerStyle}>
-          <div style={addCourseButtonStyle} onClick={toggleModal}>
-            + Add a course
-          </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "40px", paddingLeft: "30px", width: "100%" }}>
+          {Object.keys(courses)
+            .sort((a, b) => b.localeCompare(a))
+            .map((key, index) => {
+              // extract year and semester
+              const matches = key.match(/(\d{2,4})(Spring|Summer|Fall|Winter)/);
+              const year = matches ? matches[1] : key;
+              const semester = matches ? matches[2] : "";
+
+              return (
+                <div key={key} style={{ width: "100%" }}>
+                  <h3 style={{ fontWeight: "bold", fontSize: "20px", marginBottom: "10px" }}>
+                    {semester} {year} 
+                  </h3>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "20px", alignItems: "center" }}>
+                    {courses[key].map((course, idx) => (
+                      <SemesterCourses
+                        key={idx}
+                        yearInfo={key}
+                        semesterInfo={[course]}
+                        courseGroup={index}
+                        numCourses={Object.keys(courses).length}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+            <div style={addCourseButtonStyle} onClick={toggleModal}>
+              + Add a course
+            </div>
         </div>
       </div>
+
       <CourseModal title="ADD COURSE" open={isModalOpen} onCancel={toggleModal}>
         {userInfo?.isStudent ? (
           <RelationForm onFinish={handleAddCourse} onCancel={toggleModal} />

--- a/frontend/src/pages/dashboard/semesterCourses/course.js
+++ b/frontend/src/pages/dashboard/semesterCourses/course.js
@@ -2,26 +2,38 @@
   import { useNavigate } from "react-router-dom";
   import { GlobalContext } from "../../../App";
 
-  // Consider extracting styles for better maintainability and performance
-  const courseStyle = {
-      width: "230px",
-      marginRight: "15px",
-      marginBottom: "15px",
-      cursor: "pointer",
-  };
+const courseStyle = {
+    width: "230px",
+    height: "140px",
+    cursor: "pointer",
+    overflow: "hidden", 
+    boxShadow: "0px 2px 5px rgba(0, 0, 0, 0.1)",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+    backgroundColor: "#F5F5F5",
+};
 
-  const courseHeaderStyle = {
-      backgroundColor: "#f0f2f5",
-      height: "85px",
-      paddingLeft: "10px",
-  };
+const courseHeaderStyle = {
+    backgroundColor: "#f0f2f5",
+    height: "85px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    padding: "10px",
+    fontWeight: "bold",
+    fontSize: "16px",
+    color: "#333",
+};
 
-  const courseFooterStyle = {
-      backgroundColor: "#1b807c",
-      paddingLeft: "10px",
-      lineHeight: "40px",
-      color: "white",
-  };
+const courseFooterStyle = {
+    backgroundColor: "#1b807c",
+    color: "white",
+    textAlign: "center",
+    padding: "12px", 
+    fontSize: "14px",
+    fontWeight: "bold", 
+};
 
   /**
    * Displays a single course with navigation based on user role
@@ -47,15 +59,14 @@
           navigate(destination);
       }
 
-      return (
-          <div style={courseStyle} onClick={handleCourseClick}>
-              <div style={courseHeaderStyle}>
-                  <h3>{code}</h3>
-                  <span>{name}</span>
-              </div>
-              <div style={courseFooterStyle}>
-                  {assignments} assignments
-              </div>
-          </div>
-      );
-  }
+    return (
+        <div style={courseStyle} onClick={handleCourseClick}>
+            <div style={courseHeaderStyle}>
+                <span>{name}</span>
+            </div>
+            <div style={courseFooterStyle}>
+                {assignments} Assignments
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/dashboard/semesterCourses/index.js
+++ b/frontend/src/pages/dashboard/semesterCourses/index.js
@@ -1,3 +1,4 @@
+import { courseInfo } from "../../createRubric/mock";
 import Course from "./course";
 
 export default function SemesterCourses({
@@ -10,12 +11,20 @@ export default function SemesterCourses({
   let year = matches && matches[1];
   let semester = matches && matches[2];
 
+  const courseContainerStyle = {
+    display: "flex",
+    flexDirection: "column", 
+    gap: "15px", 
+  };
+
   return (
-      <div>
+    <div>
       <h3>{year && semester ? `${semester} ${year}` : null}</h3>
+      <div style={courseContainerStyle}>
         {semesterInfo?.map((item, index) => (
           <Course key={index} courseInfo={item} />
         ))}
       </div>
+    </div>
   );
 }


### PR DESCRIPTION
Edited styling of course blocks, and flexbox grouped by semester; not yet ordered

Before:
<img width="649" alt="Screenshot 2025-03-04 at 3 54 35 PM" src="https://github.com/user-attachments/assets/93295d57-ffc1-418d-8718-6aa10cc34b9f" />

After:
<img width="606" alt="Screenshot 2025-03-04 at 3 46 07 PM" src="https://github.com/user-attachments/assets/4de94465-3af0-481f-a4fb-590ca192c89a" />

#151 
