### PR TITLE
removed docker_client dependency in submission.py

### DIFF
--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -1,5 +1,4 @@
 import uuid
-import docker_client
 import json
 import sys
 from werkzeug.utils import secure_filename


### PR DESCRIPTION
- removed `import docker_client` dependency which required docker client to be open when running tests
- docker client no longer needs to be open when running integration tests