### PR TITLE
fixed bad endpoint GET /get_assignment

### DIFF
--- a/backend/routes/assignment.py
+++ b/backend/routes/assignment.py
@@ -51,7 +51,7 @@ def get_assignment():
     @param assignment_id    the id of the assignment
     '''
     assignment_id = request.args.get("assignment_id")
-    assignment_obj = db.session.query(Assignment).filter_by(id=assignment_id)
+    assignment_obj = db.session.query(Assignment).filter_by(id=assignment_id).first()
 
     if not assignment_obj:
         return jsonify({"message": "Assignment not found"}), 404

--- a/backend/test/unit/test_assignment.py
+++ b/backend/test/unit/test_assignment.py
@@ -61,7 +61,8 @@ def test_update_assignment_not_found(client, mocker):
 def test_get_assignment_success(client, mocker):
     mock_query = mocker.patch("routes.assignment.db.session.query")
     mock_assignment = Assignment(id="assignment-uuid", name="Test Assignment")
-    mock_query.return_value.filter_by.return_value = mock_assignment
+    mock_filter_by = mock_query.return_value.filter_by
+    mock_filter_by.return_value.first.return_value = mock_assignment
 
     resp = client.get("/get_assignment?assignment_id=assignment-uuid")
 
@@ -69,13 +70,16 @@ def test_get_assignment_success(client, mocker):
     assert resp.json["id"] == "assignment-uuid"
     assert resp.json["name"] == "Test Assignment"
 
-    mock_query.return_value.filter_by.assert_called_once_with(id="assignment-uuid")
+    mock_filter_by.assert_called_once_with(id="assignment-uuid")
 
 def test_get_assignment_empty(client, mocker):
     mock_query = mocker.patch("routes.assignment.db.session.query")
-    mock_query.return_value.filter_by.return_value = []
+    mock_filter_by = mock_query.return_value.filter_by
+    mock_filter_by.return_value.first.return_value = None
+
     resp = client.get("/get_assignment?assignment_id=empty-uuid")
     assert resp.status_code == 404
+    assert resp.json["message"] == "Assignment not found"
 
 def test_create_assignment_success(client, mocker):
     mock_query = mocker.patch("routes.assignment.db.session.query")


### PR DESCRIPTION
endpoint returns a query object, not an actual assignment

this results in the assignment settings page not working properly