### PR TITLE
Fixing submission timeout handling 

### DIFF
--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -15,7 +15,7 @@ from flask_cors import cross_origin
 from api import db
 from api.models import Assignment, Submission, User, Enrollment, TestCaseResult, TestCase
 from api.schemas import AssignmentSchema, SubmissionSchema, UserSchema, EnrollmentSchema
-from util.errors import BadRequestError, InternalProcessingError, ConflictError, NotFoundError, ForbiddenError, ServerTimeoutError
+from util.errors import BadRequestError, InternalProcessingError, ConflictError, NotFoundError, ServerTimeoutError, SubmissionTimeoutError
 from datetime import datetime, timezone
 from sqlalchemy import desc, func
 from ai_integration import async_get_ai_feedback
@@ -114,9 +114,53 @@ def upload_submission():
             capture_output=True, 
             timeout=assignment.autograder_timeout)
     except subprocess.TimeoutExpired:
+        # clean up container
+        container.exec_run(f"rm -rf /autograder/submission/{filename}")
+        container.exec_run(f"rm -f /autograder/source/{filename}")
         container.stop()
         os.chdir(current_dir)
-        raise ServerTimeoutError("Submitted program took too long to run")
+
+        # upload failed submission to db
+        timeout_result = {
+            "tests": [
+                {
+                    "name": "Submission Timeout",
+                    "score": 0,
+                    "max_score": 0,
+                    "status": "failed",
+                    "output": "The submission did not complete within the time limit."
+                }
+            ],
+            "leaderboard": [],
+            "visibility": "visible",
+            "execution_time": f"{assignment.autograder_timeout:.2f}",
+            "score": 0
+        }
+
+        submission_count = db.session.query(Submission).filter_by(student_id=student_id, assignment_id=assignment_id).count()
+        old = db.session.query(Submission).filter_by(student_id=student_id, assignment_id=assignment_id, active=True)
+        if old:
+            old.update({'active': False})
+        
+        failed_submission = Submission(
+            id=uuid.uuid4(),
+            file_name=filename,
+            student_id=uuid.UUID(student_id),
+            assignment_id=uuid.UUID(assignment_id),
+            student_code_file=open(file_path, 'rb').read(),
+            results=json.dumps(timeout_result).encode(),
+            score=0,
+            execution_time=float(assignment.autograder_timeout),
+            submitted_at=datetime.now(),
+            active=True,
+            completed=False,
+            submission_number=submission_count + 1,
+            ai_feedback=None
+        )
+        db.session.add(failed_submission)
+        db.session.commit()
+
+        raise SubmissionTimeoutError("Submitted program took too long to run", failed_submission.id)
 
     if exec_proc.returncode != 0:
         os.chdir(current_dir)

--- a/backend/util/errors.py
+++ b/backend/util/errors.py
@@ -15,6 +15,12 @@ class ServerTimeoutError(Exception):
     def __init__(self, message="Server timeout error"):
         super().__init__(message)
 
+# subclass of ServerTimeoutError specific for submission timeouts
+class SubmissionTimeoutError(ServerTimeoutError):
+    def __init__(self, message="Submission timeout error", submission_id=None):
+        super().__init__(message)
+        self.submission_id = submission_id
+
 class ConflictError(Exception):
     status_code = 409
     def __init__(self, message="Conflict error"):
@@ -43,6 +49,16 @@ def register_error_handlers(app):
     @app.errorhandler(ServerTimeoutError)
     def handle_server_timeout_error(error):
         return jsonify({"message": str(error)}), error.status_code
+    
+    @app.errorhandler(SubmissionTimeoutError)
+    def handle_submission_timeout_error(error):
+        return (
+            jsonify({
+                "message": str(error),
+                "submission_id": getattr(error, "submission_id", None)
+            }),
+            error.status_code
+        )
     
     @app.errorhandler(ConflictError)
     def handle_conflict_error(error):

--- a/frontend/src/components/UploadModal.js
+++ b/frontend/src/components/UploadModal.js
@@ -142,6 +142,12 @@ export default function UploadModal({
       navigateToResults(responseData.submissionID);
     } catch (error) {
       console.error("Error uploading file:", error);
+      
+      // check if we had a submission timeout error
+      if (error.response && error.response.data.submission_id) {
+        // Navigate to results if submission_id is in the response data
+        navigateToResults(error.response.data.submission_id);
+      }
     }
     finally {
       setLoading(false); // Hide loading overlay

--- a/frontend/src/pages/assignments/assignment_modal.js
+++ b/frontend/src/pages/assignments/assignment_modal.js
@@ -3,10 +3,13 @@ import { InboxOutlined } from '@ant-design/icons';
 import { useState, useContext } from "react";
 import { GlobalContext } from "../../App";
 import { useNavigate } from "react-router-dom";
+import { uploadSubmission } from "../../services/submission";
+import LoadingOverlay from "../../components/LoadingOverlay";
 
 export default function AssignmentModal({ open, onCancel, assignmentID, assignmentTitle }) {
   const [file, setFile] = useState(null);
   const { userInfo } = useContext(GlobalContext);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleFileChange = (info) => {
@@ -31,20 +34,21 @@ export default function AssignmentModal({ open, onCancel, assignmentID, assignme
     formData.append('assignment_id', assignmentID);
 
     try {
-      const response = await fetch(process.env.REACT_APP_API_URL + "/upload_submission", {
-        method: "POST",
-        body: formData,
-      });
-
-      // if (!response.ok) {
-      //   throw new Error("Network response was not ok");
-      // }
-
-      const responseData = await response.json();
+      setLoading(true);
+      const response = await uploadSubmission(formData)
+      const responseData = response.data;
       navigateToResults(responseData.submissionID);
     } catch (error) {
       console.error("Error uploading file:", error);
-      message.error("Failed to upload file. Please try again.");
+
+      // check if we had a submission timeout error
+      if (error.response && error.response.data.submission_id) {
+        // Navigate to results if submission_id is in the response data
+        navigateToResults(error.response.data.submission_id);
+      }
+    }
+    finally {
+      setLoading(false);
     }
   };
 
@@ -57,6 +61,8 @@ export default function AssignmentModal({ open, onCancel, assignmentID, assignme
   };
 
   return (
+    <>
+    <LoadingOverlay loading={loading}/> 
     <Modal title="Submit Assignment" open={open} onCancel={onCancel} footer={null}>
       <Form layout="vertical">
         <Form.Item name="upload">
@@ -83,5 +89,6 @@ export default function AssignmentModal({ open, onCancel, assignmentID, assignme
         </Form.Item>
       </Form>
     </Modal>
+    </>
   );
 }


### PR DESCRIPTION
#214

Changes:
- When a submission times out, a ```Submission``` database entry is made.
- Docker container files are cleaned up if a timeout occurs.
- Loader added for first submission upload modal (the upload modal that pops up when you click on the assignment from dashboard). This modal has also been refactored to use updated axios handlers.
- New ```SubmissionTimeoutError``` that is a subclass of ```ServerTimeoutError``` but with ```submission_id```. This is necessary for navigating to the results page after a submission times out.

![image](https://github.com/user-attachments/assets/91a28dab-3281-4a3b-bac2-8e2a7e2d8b99)
