### PR TITLE
User error handling

### DIFF
--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -131,6 +131,10 @@ def get_user_by_id():
     '''
     insid = request.args.get("id")
 
+    if not insid:
+        raise BadRequestError("Missing user id")
+
+
     instructor = db.session.query(User).filter_by(id=insid)
     instructor = UserSchema().dump(instructor, many=True)[0]
 
@@ -141,9 +145,20 @@ def get_user_by_id():
 def delete_user():
     assert current_app
     user_id = request.args.get("id")
-    User.query.filter_by(id=user_id).delete()
+    if not user_id:
+        raise BadRequestError("Missing user id")
+
+    
+    db_user = User.query.filter_by(id=user_id).first()
+    if not db_user:
+        raise NotFoundError("User Not Found")
     # user = UserSchema().dump(user)
-    db.session.commit()
+    try:
+        db.session.delete(db_user)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        raise InternalProcessingError("Error deleting user")
     return "Success", 200
 
 @user.route('/update_account', methods=["PUT", "POST"])
@@ -158,11 +173,19 @@ def update_account():
     '''
     # Extract required and optional data from the request
     user_id = request.json.get('id')
+
+    if not user_id:
+        raise BadRequestError("Missing user id")
+    
     new_name = request.json.get('name')
     new_password = request.json.get('password')
 
+
     # Find the user in the database
     user = db.session.query(User).filter_by(id=user_id).first()
+
+    if not user:
+        raise NotFoundError("User Not Found")
 
     # Update the fields if provided
     if new_name:
@@ -171,7 +194,11 @@ def update_account():
         user.password = new_password
 
     # Commit changes to the database
-    db.session.commit()
+    try:
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        raise InternalProcessingError("Error updating account")
 
     # Return a success response
     return jsonify({"message": "Account updated successfully"}), 200

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -131,7 +131,7 @@ def get_user_by_id():
     '''
 
     try:
-        insid = uuid.UUID(request.args.get("id"))
+        insid = str(uuid.UUID(request.args.get("id")))
     except (ValueError, TypeError):
         raise BadRequestError("Invalid or missing UUID for user id")
 
@@ -152,17 +152,23 @@ def get_user_by_id():
 @cross_origin()
 def delete_user():
     assert current_app
-    user_id = request.args.get("id")
-    if not user_id:
-        raise BadRequestError("Missing user id")
+
+    user_id = request.args.get("id") 
+    if not user_id: 
+        raise BadRequestError("Missing User id")
+
+    try: 
+        user_id = str(uuid.UUID(user_id))
+    except(ValueError, TypeError):
+        raise BadRequestError("Invalid  user id") 
 
     
-    db_user = User.query.filter_by(id=user_id).first()
-    if not db_user:
+    user = db.session.query(User).filter_by(id=user_id).first()
+    if not user:
         raise NotFoundError("User Not Found")
     # user = UserSchema().dump(user)
     try:
-        db.session.delete(db_user)
+        db.session.delete(user)
         db.session.commit()
     except Exception as e:
         db.session.rollback()

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -129,14 +129,22 @@ def get_user_by_id():
     Requires from the frontend a JSON containing:
     @param id    the instructor id
     '''
-    insid = request.args.get("id")
+
+    try:
+        insid = uuid.UUID(request.args.get("id"))
+    except (ValueError, TypeError):
+        raise BadRequestError("Invalid or missing UUID for user id")
 
     if not insid:
         raise BadRequestError("Missing user id")
 
 
-    instructor = db.session.query(User).filter_by(id=insid)
-    instructor = UserSchema().dump(instructor, many=True)[0]
+    instructor_obj = db.session.query(User).filter_by(id=insid).first() 
+    if not instructor_obj: 
+        raise NotFoundError("User does not exist")
+    
+    instructor = UserSchema().dump(instructor_obj)
+
 
     return jsonify(instructor)
 

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -130,13 +130,15 @@ def get_user_by_id():
     @param id    the instructor id
     '''
 
-    try:
-        insid = str(uuid.UUID(request.args.get("id")))
-    except (ValueError, TypeError):
-        raise BadRequestError("Invalid or missing UUID for user id")
-
-    if not insid:
+    insid = request.args.get("id")
+    if not insid: 
         raise BadRequestError("Missing user id")
+
+    try:
+        insid = str(uuid.UUID(insid))
+    except (ValueError, TypeError):
+        raise BadRequestError("Invalid user id")
+
 
 
     instructor_obj = db.session.query(User).filter_by(id=insid).first() 
@@ -160,7 +162,7 @@ def delete_user():
     try: 
         user_id = str(uuid.UUID(user_id))
     except(ValueError, TypeError):
-        raise BadRequestError("Invalid  user id") 
+        raise BadRequestError("Invalid user id") 
 
     
     user = db.session.query(User).filter_by(id=user_id).first()
@@ -187,9 +189,15 @@ def update_account():
     '''
     # Extract required and optional data from the request
     user_id = request.json.get('id')
-
     if not user_id:
         raise BadRequestError("Missing user id")
+    
+    try: 
+        user_id = str(uuid.UUID(user_id))
+    except(ValueError, TypeError):
+        raise BadRequestError("Invalid  user id") 
+    
+
     
     new_name = request.json.get('name')
     new_password = request.json.get('password')

--- a/backend/test/it/test_user_it.py
+++ b/backend/test/it/test_user_it.py
@@ -51,7 +51,7 @@ def test_user_login_integration(client):
 
 def test_delete_user_integration(client):
     # First, create the user
-    client.post('/create_user', json={
+    response = client.post('/create_user', json={
         "name": "Bob",
         "email_address": "bob@example.com",
         "password": "bob123",
@@ -59,16 +59,28 @@ def test_delete_user_integration(client):
         "role": 1
     })
 
+    assert response.status_code == 201 
+
+    data = response.get_json() 
+    user_id = data["id"]
+
     # Delete the user
-    response = client.delete('/delete_user', json={
-        "eid": "EID789"
+    response = client.delete('/delete_user', query_string={
+        "id": user_id
     })
 
     assert response.status_code == 200
 
+    # Confirm user is gone
+    get_again = client.get('/get_user_by_id', query_string={
+        "id": user_id
+    })
+
+    assert get_again.status_code == 404
+
 def test_update_user_account_integration(client):
     # First, create the user
-    client.post('/create_user', json={
+    response = client.post('/create_user', json={
         "name": "Charlie",
         "email_address": "charlie@example.com",
         "password": "charlie123",
@@ -76,11 +88,27 @@ def test_update_user_account_integration(client):
         "role": 1
     })
 
+    assert response.status_code == 201 
+
+    data = response.get_json() 
+    user_id = data["id"]
+
     # Update the user
     response = client.put('/update_account', json={
-        "eid": "EID999",
-        "new_name": "Charles",
-        "new_password": "charles@example.com"
+        "id": user_id, 
+        "name": "Charles",
+        "password": "charles123"
     })
 
     assert response.status_code == 200
+
+    get_again = client.get('/get_user_by_id', query_string={
+        "id": user_id
+    })
+
+    assert get_again.status_code == 200
+
+    data = get_again.get_json() 
+    assert data["name"] == "Charles" 
+    assert data["password"] == "charles123"
+

--- a/backend/test/unit/test_user.py
+++ b/backend/test/unit/test_user.py
@@ -1,5 +1,6 @@
 import pytest
 from api import create_app
+import uuid
 
 @pytest.fixture
 def app():
@@ -248,3 +249,46 @@ def test_update_account(client, mocker):
     mock_query.assert_called_once()
     mock_query.return_value.filter_by.assert_called_once_with(id="123")
     mock_commit.assert_called_once()
+
+
+
+def test_get_user_by_id(client, mocker):
+    """Test the /get_user_by_id route."""
+
+    random_uuid = uuid.uuid4() 
+    user_mock = mocker.Mock()
+    user_mock.id = random_uuid
+    user_mock.name = "Old Name"
+    user_mock.password = "oldpassword"
+    user_mock.coding_insights = "No history."
+    user_mock.email_address =  "user@gmail.com"
+    user_mock.role =  "student"
+    user_mock.sis_user_id = "123"
+
+
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = user_mock
+
+    response = client.get("/get_user_by_id", query_string={"id": str(random_uuid)})
+
+    assert response.status_code == 200
+    assert response.json == {
+        "id" : str(random_uuid),
+        "name": "Old Name",
+        "password": "oldpassword",
+        "coding_insights": "No history.",
+        "email_address":  "user@gmail.com",
+        "role":  "student",
+        "sis_user_id": "123"
+    }
+
+    mock_query.assert_called_once() 
+    mock_query.return_value.filter_by.assert_called_once_with(id=random_uuid)
+
+    
+
+
+
+
+    
+

--- a/backend/test/unit/test_user.py
+++ b/backend/test/unit/test_user.py
@@ -212,19 +212,34 @@ def test_get_user_by_email_not_found(client, mock_user_query):
 
 def test_delete_user(client, mocker):
     """Test the /delete_user route."""
-    mock_db = mocker.patch("routes.user.db")
-    mock_filter = mocker.patch("routes.user.User.query")
 
-    mock_filter.filter_by.return_value.delete.return_value = 1
+    random_uuid = uuid.uuid4()
+    user_mock = mocker.Mock() 
+    user_mock.id = random_uuid
+    
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = user_mock
 
-    response = client.delete("/delete_user?id=123")
+    # Mock db.session.delete and commit
+    mock_delete = mocker.patch("routes.user.db.session.delete")
+    mock_commit = mocker.patch("routes.user.db.session.commit")
+
+    response = client.delete("/delete_user", query_string={"id" : str(random_uuid)})
 
     assert response.status_code == 200
     assert response.data.decode() == "Success"
 
-    mock_filter.filter_by.assert_called_once_with(id="123")
-    mock_filter.filter_by.return_value.delete.assert_called_once()
-    mock_db.session.commit.assert_called_once()
+    # Check that filter_by was called with correct id
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+
+    # Check that first() was called to fetch the user
+    mock_query.return_value.filter_by.return_value.first.assert_called_once()
+
+    # Check that delete was called with the mock user
+    mock_delete.assert_called_once_with(user_mock)
+
+    # Check that commit was called
+    mock_commit.assert_called_once()
 
 
 def test_update_account(client, mocker):
@@ -283,7 +298,7 @@ def test_get_user_by_id(client, mocker):
     }
 
     mock_query.assert_called_once() 
-    mock_query.return_value.filter_by.assert_called_once_with(id=random_uuid)
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
 
     
 

--- a/backend/test/unit/test_user.py
+++ b/backend/test/unit/test_user.py
@@ -242,12 +242,76 @@ def test_delete_user(client, mocker):
     mock_commit.assert_called_once()
 
 
+def test_delete_user_missing_id(client, mocker):
+    """Test the /delete_user route."""
+
+
+    response = client.delete("/delete_user")
+
+    assert response.status_code == 400
+    data = response.get_json() 
+    assert data['message'] == "Missing User id"
+
+def test_delete_user_invalid_id(client, mocker):
+    """Test the /delete_user route."""
+
+
+    response = client.delete("/delete_user", query_string={"id" : "123"})
+
+    assert response.status_code == 400
+    data = response.get_json() 
+    assert data['message'] == "Invalid user id"
+
+def test_delete_user_not_found(client, mocker):
+    """Test the /delete_user route."""
+
+    random_uuid = random_uuid = uuid.uuid4() 
+
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = None
+
+
+    response = client.delete("/delete_user", query_string={"id" : str(random_uuid)})
+
+    assert response.status_code == 404
+    data = response.get_json() 
+    assert data['message'] == "User Not Found"
+
+    mock_query.assert_called_once() 
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+
+
+def test_delete_user_rolls_back_on_exception(client, mocker):
+    random_uuid = uuid.uuid4()
+    user_mock = mocker.Mock() 
+    user_mock.id = random_uuid
+
+    mock_session = mocker.patch("routes.user.db.session")
+
+    
+    mock_session.query.return_value.filter_by.return_value.first.return_value = user_mock
+
+    mock_session.delete.return_value = None
+    mock_session.commit.side_effect = Exception("Simulated DB failure")
+
+
+    response = client.delete("/delete_user", query_string={"id" : str(random_uuid)})
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["message"] == "Error deleting user"
+
+    mock_session.rollback.assert_called_once()
+
 def test_update_account(client, mocker):
     """Test the /update_account route."""
-    payload = {"id": "123", "name": "Updated Name", "password": None}
+
+    random_uuid = uuid.uuid4()
+
+    payload = {"id": str(random_uuid), "name": "Updated Name", "password": "Updated Password"}
     
     user_mock = mocker.Mock()
-    user_mock.id = "123"
+    user_mock.id = str(random_uuid)
     user_mock.name = "Old Name"
     user_mock.password = "oldpassword"
     
@@ -262,8 +326,112 @@ def test_update_account(client, mocker):
     assert response.json["message"] == "Account updated successfully"
 
     mock_query.assert_called_once()
-    mock_query.return_value.filter_by.assert_called_once_with(id="123")
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
     mock_commit.assert_called_once()
+
+def test_update_account_only_user(client, mocker):
+    """Test the /update_account route."""
+
+    random_uuid = uuid.uuid4()
+
+    payload = {"id": str(random_uuid), "name": "Updated Name"}
+    
+    user_mock = mocker.Mock()
+    user_mock.id = str(random_uuid)
+    user_mock.name = "Old Name"
+    user_mock.password = "oldpassword"
+    
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = user_mock
+
+    mock_commit = mocker.patch("routes.user.db.session.commit")
+    
+    response = client.put("/update_account", json=payload)
+    
+    assert response.status_code == 200
+    assert response.json["message"] == "Account updated successfully"
+
+    mock_query.assert_called_once()
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+    mock_commit.assert_called_once()
+
+
+def test_update_account_only_password(client, mocker):
+    """Test the /update_account route."""
+
+    random_uuid = uuid.uuid4()
+
+    payload = {"id": str(random_uuid), "password": "Updated Password"}
+    
+    user_mock = mocker.Mock()
+    user_mock.id = str(random_uuid)
+    user_mock.name = "Old Name"
+    user_mock.password = "oldpassword"
+    
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = user_mock
+
+    mock_commit = mocker.patch("routes.user.db.session.commit")
+    
+    response = client.put("/update_account", json=payload)
+    
+    assert response.status_code == 200
+    assert response.json["message"] == "Account updated successfully"
+
+    mock_query.assert_called_once()
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+    mock_commit.assert_called_once()
+
+def test_update_account_missing_id(client, mocker):
+    """Test the /update_account route."""
+
+    response = client.put("/update_account", json={})
+
+    assert response.status_code == 400
+    data = response.get_json() 
+    assert data['message'] == "Missing user id"
+
+
+def test_update_account_missing_user(client, mocker):
+    """Test the /update_account route."""
+
+    
+    random_uuid = random_uuid = uuid.uuid4() 
+
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = None
+
+
+    response = client.put("/update_account", json={"id" : str(random_uuid)})
+
+    assert response.status_code == 404
+    data = response.get_json() 
+    assert data['message'] == "User Not Found"
+
+    mock_query.assert_called_once() 
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+
+def test_update_user_rolls_back_on_exception(client, mocker):
+    random_uuid = uuid.uuid4()
+    user_mock = mocker.Mock() 
+    user_mock.id = random_uuid
+
+    payload = {"id": str(random_uuid), "password": "Updated Password"}
+
+    mock_session = mocker.patch("routes.user.db.session")
+    mock_session.query.return_value.filter_by.return_value.first.return_value = user_mock
+
+    mock_session.commit.side_effect = Exception("Simulated DB failure")
+
+
+    response = client.put("/update_account", json=payload)
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["message"] == "Error updating account"
+
+    mock_session.rollback.assert_called_once()
+
 
 
 
@@ -299,6 +467,46 @@ def test_get_user_by_id(client, mocker):
 
     mock_query.assert_called_once() 
     mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+
+
+def test_get_user_by_id_not_found(client, mocker):
+    """Test the /get_user_by_id route."""
+
+    random_uuid = uuid.uuid4() 
+
+    mock_query = mocker.patch("routes.user.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = None
+
+    response = client.get("/get_user_by_id", query_string={"id": str(random_uuid)})
+
+    assert response.status_code == 404
+    data = response.get_json() 
+    assert data['message'] == "User does not exist"
+
+    mock_query.assert_called_once() 
+    mock_query.return_value.filter_by.assert_called_once_with(id=str(random_uuid))
+
+
+def test_get_user_by_id_missing_id(client, mocker):
+    """Test the /get_user_by_id route."""
+
+    response = client.get("/get_user_by_id")
+
+    assert response.status_code == 400
+    data = response.get_json() 
+    assert data['message'] == "Missing user id"
+
+
+
+def test_get_user_by_id_non_uuid(client, mocker):
+    """Test the /get_user_by_id route."""
+
+    response = client.get("/get_user_by_id", query_string={"id" : "123"})
+
+    assert response.status_code == 400
+    data = response.get_json() 
+    assert data['message'] == "Invalid user id"
+
 
     
 


### PR DESCRIPTION
finished adding more user error handling 

get_user_by_id()
-make sure user_id provided is a proper uuid
-make sure that a user_id is provided in the body of the request
-throw 404 if not found in database

delete_user()
-make sure that user_id is provided in the body of the request
-make sure user_id provided is a proper uuid
-throw 404 if not found in database
-add try and rollbacks for db commits

update_account()
-make sure that the user_id is provided in the body of the request
-make sure user_id provided is a proper uuid
-throw 404 if not found in database
-add try and rollbacks for db commits

-updated some tests that had mistakes in them eg trying to invoke update_user with eid instead of the actual user id
-added unit testing to test these cases as well
