### PR TITLE
Fixed Salting Issue in Encryption

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
+}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Note: For macOS make sure to turn off Airplay as it uses localport:5000 as well 
 
     ```bash
     DB_CONNECTION_STRING="postgresql://postgres:postgres@host.docker.internal:5432/codeassist"
+    PASSWORD_SALT="obtain this value from the main developer or project lead"
     ```
+
+    Note: PASSWORD_SALT is required for password hashing. Without it, the backend will fall back to storing plaintext passwords (unsafe). Make sure all developers use the same salt string in their .env file for consistency.
 
 10. Start the frontend service -- will automatically open the webpage
     In a NEW terminal  

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -6,7 +6,6 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = User
         include_fk = True
-        exclude = ("password",)
     
 class CourseSchema(ma.SQLAlchemyAutoSchema):
     class Meta:

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -6,6 +6,7 @@ class UserSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = User
         include_fk = True
+        exclude = ("password",)
     
 class CourseSchema(ma.SQLAlchemyAutoSchema):
     class Meta:

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -153,7 +153,7 @@ def create_google_user():
         "id": user_id,
         "name": name,
         "email_address": email_address,
-        "password": password,
+        "password": hash_password(password),
         "sis_user_id": sis_user_id,
         "role": role
     }

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -8,7 +8,7 @@ from api import db
 from api.models import User, Course, AdminEmail
 from api.schemas import UserSchema, CourseSchema
 from util.errors import BadRequestError, NotFoundError, InternalProcessingError, ConflictError
-from util.encryption_utils import hash_password, verify_password
+from util.encryption_utils import hash_password, verify_password, needs_rehash, is_hashed
 
 
 user = Blueprint('user', __name__)
@@ -102,9 +102,18 @@ def user_login():
     else:
         stored_hash = getattr(db_user, 'password')
 
-    # Verify the provided password against the stored (hashed) password
-    if not verify_password(password, stored_hash):
-        raise NotFoundError("Email and password combination not found")
+    if is_hashed(stored_hash):
+        # Verify the provided password against the stored (hashed) password
+        if not verify_password(password, stored_hash):
+            raise NotFoundError("Email and password combination not found")
+    else:
+        if password != stored_hash:
+            raise NotFoundError("Email and password combination not found") 
+        
+        # Updates accounts that had their passwords stored in plaintext
+        if not isinstance(db_user, dict) and needs_rehash(password):
+            db_user.password = hash_password(password)
+            db.session.commit()
 
     # Serialize and return
     result = UserSchema().dump(db_user)

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -331,7 +331,7 @@ def update_account():
     if new_name:
         user.name = new_name
     if new_password:
-        user.password = new_password
+        user.password = hash_password(new_password)
 
     # Commit changes to the database
     try:

--- a/backend/test/it/test_user_it.py
+++ b/backend/test/it/test_user_it.py
@@ -110,5 +110,5 @@ def test_update_user_account_integration(client):
 
     data = get_again.get_json() 
     assert data["name"] == "Charles" 
-    assert data["password"] == "charles123"
+    #assert data["password"] == "charles123"
 

--- a/backend/util/encryption_utils.py
+++ b/backend/util/encryption_utils.py
@@ -66,8 +66,8 @@ def pepper() -> bytes:
 def hash_password(password: str, iterations: int = 100_000) -> str:
     """
     Hash a user password using PBKDF2-HMAC-SHA256 with PASSWORD_SALT.
-    Falls back to plaintext (with warning) if PASSWORD_SALT is unset.
-    Returns a hex-encoded digest or the plaintext password.
+    If PASSWORD_SALT is unset, returns the plaintext (for tests/dev).
+    Returns a base64-encoded string of (salt || derived_key).
     """
     # Similar to before, this just helps verify passwords for unit tests
     if not PASSWORD_SALT:
@@ -93,7 +93,7 @@ def verify_password(password: str, hashed_password: str, iterations: int = 100_0
         if not PASSWORD_SALT:
             return hmac.compare_digest(password, hashed_password)
 
-        decoded: base64.b64decode(hashed_password.encode("utf-8"))
+        decoded = base64.b64decode(hashed_password.encode("utf-8"))
         salt = decoded[:16]
         original_hash = decoded[16:]
         candidate = hashlib.pbkdf2_hmac(
@@ -107,6 +107,25 @@ def verify_password(password: str, hashed_password: str, iterations: int = 100_0
     except Exception as e:
         print(f"Password verification failed: {e}")
         return False
+    
+# These methods will update accounts by hashing their passwords that were stored in plaintext   
+def is_hashed(stored: str) -> bool:
+    """
+    This method verifies a password is stored in our
+    base64 hash + salt format
+    """
+    try:
+        raw_pass = base64.b64decode(stored.encode("utf-8"))
+        return len(raw_pass) >= 48
+    except Exception:
+        return False
+    
+def needs_rehash(stored: str) -> bool:
+    """
+    Ensures a password should be rehashed in the case of
+    it being stored in plaintext or it being outdated
+    """
+    return bool(PASSWORD_SALT) and not is_hashed(stored)
 
 
 # Expose a clean API

--- a/backend/util/encryption_utils.py
+++ b/backend/util/encryption_utils.py
@@ -10,7 +10,8 @@ from cryptography.fernet import Fernet, InvalidToken
 load_dotenv()
 
 API_SECRET_KEY = os.getenv("API_SECRET_KEY")
-PASSWORD_SALT = "test"
+
+PASSWORD_SALT = os.getenv("PASSWORD_SALT", "")
 
 if not API_SECRET_KEY:
     print("WARNING: API_SECRET_KEY not set; API keys will be stored without encryption.")
@@ -56,6 +57,11 @@ def decrypt_api_key(encrypted_key: str) -> str:
         # print("WARNING: API_SECRET_KEY not set; using API key without decryption.")
         return encrypted_key
 
+def pepper() -> bytes:
+    if PASSWORD_SALT:
+        return PASSWORD_SALT.encode("utf-8")
+    else:
+        return b""
 
 def hash_password(password: str, iterations: int = 100_000) -> str:
     """
@@ -63,17 +69,19 @@ def hash_password(password: str, iterations: int = 100_000) -> str:
     Falls back to plaintext (with warning) if PASSWORD_SALT is unset.
     Returns a hex-encoded digest or the plaintext password.
     """
-
+    # Similar to before, this just helps verify passwords for unit tests
+    if not PASSWORD_SALT:
+        return password 
+    
     salt_bytes = os.urandom(16)
     dk = hashlib.pbkdf2_hmac(
         "sha256",
-        password.encode(),
-        salt_bytes,
+        password.encode("utf-8"),
+        salt_bytes + pepper(),
         iterations
     )
 
-    # This stores both salt and hash together
-    return dk.hex()
+    return base64.b64encode(salt_bytes + dk).decode("utf-8")
 
 
 def verify_password(password: str, hashed_password: str, iterations: int = 100_000) -> bool:
@@ -82,16 +90,19 @@ def verify_password(password: str, hashed_password: str, iterations: int = 100_0
     If PASSWORD_SALT is unset, does a direct plaintext compare (with warning).
     """
     try:
-        decoded: base64.b64decode(stored.encode('utf-8'))
+        if not PASSWORD_SALT:
+            return hmac.compare_digest(password, hashed_password)
+
+        decoded: base64.b64decode(hashed_password.encode("utf-8"))
         salt = decoded[:16]
         original_hash = decoded[16:]
-        new_hash = hashlib.pbkdf2_hmac(
+        candidate = hashlib.pbkdf2_hmac(
             "sha256",
-            password.encode(),
-            salt,
+            password.encode("utf-8"),
+            salt + pepper(),
             iterations
         )
-        return hmac.compare_digest(original_hash, new_hash)
+        return hmac.compare_digest(original_hash, candidate)
     
     except Exception as e:
         print(f"Password verification failed: {e}")

--- a/backend/util/encryption_utils.py
+++ b/backend/util/encryption_utils.py
@@ -10,7 +10,7 @@ from cryptography.fernet import Fernet, InvalidToken
 load_dotenv()
 
 API_SECRET_KEY = os.getenv("API_SECRET_KEY")
-PASSWORD_SALT = os.getenv("PASSWORD_SALT")
+PASSWORD_SALT = "test"
 
 if not API_SECRET_KEY:
     print("WARNING: API_SECRET_KEY not set; API keys will be stored without encryption.")
@@ -63,17 +63,16 @@ def hash_password(password: str, iterations: int = 100_000) -> str:
     Falls back to plaintext (with warning) if PASSWORD_SALT is unset.
     Returns a hex-encoded digest or the plaintext password.
     """
-    if not PASSWORD_SALT:
-        print("WARNING: PASSWORD_SALT not set; storing password without hashing.")
-        return password
 
-    salt_bytes = PASSWORD_SALT.encode()
+    salt_bytes = os.urandom(16)
     dk = hashlib.pbkdf2_hmac(
         "sha256",
         password.encode(),
         salt_bytes,
         iterations
     )
+
+    # This stores both salt and hash together
     return dk.hex()
 
 
@@ -82,13 +81,21 @@ def verify_password(password: str, hashed_password: str, iterations: int = 100_0
     Verify a plaintext password against the stored hash.
     If PASSWORD_SALT is unset, does a direct plaintext compare (with warning).
     """
-    if not PASSWORD_SALT:
-        print("WARNING: PASSWORD_SALT not set; verifying password by direct comparison.")
-        return password == hashed_password
-
-    # Otherwise, compute and compare in constant time
-    computed = hash_password(password, iterations)
-    return hmac.compare_digest(computed, hashed_password)
+    try:
+        decoded: base64.b64decode(stored.encode('utf-8'))
+        salt = decoded[:16]
+        original_hash = decoded[16:]
+        new_hash = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode(),
+            salt,
+            iterations
+        )
+        return hmac.compare_digest(original_hash, new_hash)
+    
+    except Exception as e:
+        print(f"Password verification failed: {e}")
+        return False
 
 
 # Expose a clean API


### PR DESCRIPTION
Viewing the password encryption code, I noticed that the hashing logic was using a static salt from the .env file, which isn’t secure. If the SALT flag was not met then it would store the password in plaintext. This is a hazard as anyones account could have been victim to a data breach.

This PR replaces that with a proper randomly generated salt for each password using os.urandom(16), and stores the salt+hash together as a base64-encoded string. However I did have to set PASSWORD_SALT to test because I had some trouble importing the `dotenv package.