### PR TITLE
Fix #276 : updated user roles and enable search/reset filters on enrollment page 

### DIFF
--- a/backend/routes/course.py
+++ b/backend/routes/course.py
@@ -420,25 +420,35 @@ def get_user_enrollments():
 @cross_origin()
 def get_course_enrollment():
     """
-    /get_course_enrollment gets all students enrolled in a course
-    Requires from the frontend a JSON containing:
-    @param course_id        the id of a course
+    Returns all users enrolled in a course,
+    showing their course-specific role from the Enrollment table.
     """
     course_id = request.args.get("course_id")
-    if not course_id or course_id == "":
+    if not course_id:
         raise BadRequestError("Missing course_id argument")
 
-    students = db.session.query(Enrollment.student_id).filter_by(course_id=course_id)
-    students = EnrollmentSchema().dump(students, many=True)
+    results = (
+        db.session.query(
+            User.id,
+            User.name,
+            User.email_address,
+            Enrollment.role.label("role")
+        )
+        .join(Enrollment, Enrollment.student_id == User.id)
+        .filter(Enrollment.course_id == course_id)
+        .all()
+    )
 
-    list_of_students = [x["student_id"] for x in students]
-
-    students = db.session.query(
-        User.name, User.email_address, User.id, User.role
-    ).filter(User.id.in_(list_of_students))
-    students = UserSchema().dump(students, many=True)
-
-    return jsonify(students)
+    data = [
+        {
+            "id": r.id,
+            "name": r.name,
+            "email_address": r.email_address,
+            "role": r.role
+        }
+        for r in results
+    ]
+    return jsonify(data), 200
 
 
 @course.route("/get_course_assignments", methods=["GET"])

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -371,16 +371,41 @@ def test_get_user_enrollments_missing_user_id(client):
     assert response.json["message"] == "Missing user_id argument"
 
 def test_get_course_enrollment_success(client, mocker):
+    # Mock the query chain used in the new route (query -> join -> filter)
     mock_query = mocker.patch("routes.course.db.session.query")
-    mock_query.return_value.filter_by.return_value = [mocker.Mock(student_id="student-123")]
-    mock_query.return_value.filter.return_value = [mocker.Mock(name="John Doe", email_address="john@example.com", id="student-123", role="student")]
+    mock_query_instance = mock_query.return_value
+    mock_join = mock_query_instance.join.return_value
+    mock_filter = mock_join.filter.return_value
+    # Mock .all() return value
+    mock_filter.all.return_value = [
+        mocker.Mock(
+            id="student-123",
+            name="John Doe",
+            email_address="john@example.com",
+            role="student"
+        )
+    ]
+    # Mock UserSchema
     mock_schema = mocker.patch("routes.course.UserSchema")
-    mock_schema.return_value.dump.return_value = [{"name": "John Doe", "email_address": "john@example.com", "id": "student-123", "role": "student"}]
-
+    mock_schema_instance = mock_schema.return_value
+    mock_schema_instance.dump.return_value = [
+        {
+            "id": "student-123",
+            "name": "John Doe",
+            "email_address": "john@example.com",
+            "role": "student"
+        }
+    ]
     response = client.get("/get_course_enrollment", query_string={"course_id": "course-123"})
-
     assert response.status_code == 200
-    assert response.json == [{"name": "John Doe", "email_address": "john@example.com", "id": "student-123", "role": "student"}]
+    assert response.json == [
+        {
+            "id": "student-123",
+            "name": "John Doe",
+            "email_address": "john@example.com",
+            "role": "student"
+        }
+    ]
 
 def test_get_course_enrollment_missing_course_id(client):
     response = client.get("/get_course_enrollment")

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -370,42 +370,29 @@ def test_get_user_enrollments_missing_user_id(client):
     assert response.status_code == 400
     assert response.json["message"] == "Missing user_id argument"
 
+from types import SimpleNamespace
+
 def test_get_course_enrollment_success(client, mocker):
     # Mock the query chain used in the new route (query -> join -> filter)
     mock_query = mocker.patch("routes.course.db.session.query")
     mock_query_instance = mock_query.return_value
     mock_join = mock_query_instance.join.return_value
     mock_filter = mock_join.filter.return_value
-    # Mock .all() return value
     mock_filter.all.return_value = [
-        mocker.Mock(
+        SimpleNamespace(
             id="student-123",
             name="John Doe",
             email_address="john@example.com",
             role="student"
         )
     ]
-    # Mock UserSchema
-    mock_schema = mocker.patch("routes.course.UserSchema")
-    mock_schema_instance = mock_schema.return_value
-    mock_schema_instance.dump.return_value = [
-        {
-            "id": "student-123",
-            "name": "John Doe",
-            "email_address": "john@example.com",
-            "role": "student"
-        }
-    ]
     response = client.get("/get_course_enrollment", query_string={"course_id": "course-123"})
     assert response.status_code == 200
-    assert response.json == [
-        {
-            "id": "student-123",
-            "name": "John Doe",
-            "email_address": "john@example.com",
-            "role": "student"
-        }
-    ]
+    data = response.get_json()
+    assert len(data) == 1
+    assert data[0]["id"] == "student-123"
+    assert data[0]["name"] == "John Doe"
+    assert data[0]["role"] == "student"
 
 def test_get_course_enrollment_missing_course_id(client):
     response = client.get("/get_course_enrollment")

--- a/frontend/src/pages/instructor/enrollment/index.js
+++ b/frontend/src/pages/instructor/enrollment/index.js
@@ -193,7 +193,7 @@ export default () => {
           <Form.Item>
             <Button onClick={getEnrollment}>Reset</Button>
           </Form.Item>
-        </Form>
+        </Form> 
         <Table
           columns={[
             ...columns,

--- a/frontend/src/pages/instructor/enrollment/index.js
+++ b/frontend/src/pages/instructor/enrollment/index.js
@@ -38,7 +38,9 @@ export default () => {
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [addCSVModalOpen, setAddCSVModalOpen] = useState(false);
   const [addMoreUsersModalOpen, setAddMoreUsersModalOpen] = useState(false);
+  const [originalEnrollment, setOriginalEnrollment] = useState([]); 
   const [enrollment, setEnrollment] = useState([]);
+
   const urlParams = useParams();
   const { courseInfo, updateCourseInfo } = useContext(GlobalContext);
   const { courseId } = urlParams;
@@ -58,8 +60,10 @@ export default () => {
   const getEnrollment = useCallback(() => {
     getCourseEnrollment({ course_id: courseId }).then((res) => {
       setEnrollment(res.data);
+      setOriginalEnrollment(res.data); 
     });
   }, [courseId]);
+
 
   const handleUpdateRole = useCallback(
     async (newRole, studentId) => {
@@ -156,11 +160,15 @@ export default () => {
           style={{ marginBottom: "20px" }}
           onFinish={(values) => {
             const { role, username } = values;
-            let filtered = enrollment;
+            // Always start from the full list, not the already filtered one
+            let filtered = originalEnrollment;
 
             if (role && role !== "All") {
-              filtered = filtered.filter((e) => e.role.toLowerCase() === role.toLowerCase());
+              filtered = filtered.filter(
+                (e) => e.role.toLowerCase() === role.toLowerCase()
+              );
             }
+
             if (username) {
               filtered = filtered.filter((e) =>
                 e.name.toLowerCase().includes(username.toLowerCase())
@@ -169,6 +177,7 @@ export default () => {
 
             setEnrollment(filtered);
           }}
+
         >
           <Form.Item name="role">
             <Select
@@ -191,7 +200,7 @@ export default () => {
             </Button>
           </Form.Item>
           <Form.Item>
-            <Button onClick={getEnrollment}>Reset</Button>
+            <Button onClick={() => setEnrollment(originalEnrollment)}>Reset</Button>
           </Form.Item>
         </Form> 
         <Table

--- a/frontend/src/pages/instructor/enrollment/index.js
+++ b/frontend/src/pages/instructor/enrollment/index.js
@@ -142,7 +142,7 @@ export default () => {
 
   useEffect(() => {
     getEnrollment();
-  }, [getEnrollment]);
+  }, [getEnrollment, courseId]);
 
   return (
     <>
@@ -151,28 +151,47 @@ export default () => {
         style={{ borderBottom: "1px solid #f0f0f0" }}
       />
       <Card bordered={false}>
-        <Form layout="inline" style={{ marginBottom: "20px" }}>
+        <Form
+          layout="inline"
+          style={{ marginBottom: "20px" }}
+          onFinish={(values) => {
+            const { role, username } = values;
+            let filtered = enrollment;
+
+            if (role && role !== "All") {
+              filtered = filtered.filter((e) => e.role.toLowerCase() === role.toLowerCase());
+            }
+            if (username) {
+              filtered = filtered.filter((e) =>
+                e.name.toLowerCase().includes(username.toLowerCase())
+              );
+            }
+
+            setEnrollment(filtered);
+          }}
+        >
           <Form.Item name="role">
             <Select
               placeholder="view by role"
               style={{ width: "180px" }}
               options={[
-                { label: "All", value: "0" },
-                { label: "Students", value: "1" },
-                { label: "Instructors", value: "2" },
-                { label: "TAs", value: "3" },
-                { label: "Readers", value: "4" },
+                { label: "All", value: "All" },
+                { label: "Student", value: "Student" },
+                { label: "Instructor", value: "Instructor" },
+                { label: "TA", value: "TA" },
               ]}
             />
-          </Form.Item>
-          <Form.Item name="section">
-            <Input placeholder="view by section" />
           </Form.Item>
           <Form.Item name="username">
             <Input placeholder="view by name" />
           </Form.Item>
           <Form.Item>
-            <Button type="primary">search</Button>
+            <Button type="primary" htmlType="submit">
+              search
+            </Button>
+          </Form.Item>
+          <Form.Item>
+            <Button onClick={getEnrollment}>Reset</Button>
           </Form.Item>
         </Form>
         <Table
@@ -183,10 +202,10 @@ export default () => {
               dataIndex: "role",
               render: (text, record) => (
                 <Select
-                  defaultValue={text}
+                  value={text}
                   style={{ width: 120 }}
                   onChange={(value) => handleUpdateRole(value, record.id)}
-                  disabled={text === "instructor"} // Disable dropdown if the role is instructor
+                  disabled={text.toLowerCase() === "instructor"}
                 >
                   <Select.Option value="student">Student</Select.Option>
                   <Select.Option value="TA">TA</Select.Option>


### PR DESCRIPTION
Fixes Implemented
Updated /get_course_enrollment to join Enrollment and User tables.
Ensures that role updates (e.g., Student → TA) now persist after refresh or login.

Frontend:  
Fixed search and reset buttons in the Instructor 
Implemented working filters by role and username.
Table now displays correct, updated role information.

<img width="1379" height="652" alt="image" src="https://github.com/user-attachments/assets/c9f95222-7c8d-4e58-83d6-595346e6ff7a" />


