### PR TITLE
fix: student portal time rendering using browser local TZ (Issue #291)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@react-oauth/google": "^0.12.2",
         "antd": "^4.24.2",
         "classnames": "^2.3.2",
+        "moment-timezone": "^0.6.0",
         "nodemailer": "^6.9.13",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -13319,6 +13320,18 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
+      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "engines": {
         "node": "*"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@react-oauth/google": "^0.12.2",
     "antd": "^4.24.2",
     "classnames": "^2.3.2",
+    "moment-timezone": "^0.6.0",
     "nodemailer": "^6.9.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/pages/assignments/index.js
+++ b/frontend/src/pages/assignments/index.js
@@ -2,7 +2,7 @@ import { Card, Descriptions, PageHeader, Table, Button, message} from "antd";
 import { useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { GlobalContext } from "../../App";
-import moment from "moment";
+import moment from "moment-timezone";
 import AssignmentModal from "./assignment_modal";
 
 export default function Assignments() {
@@ -44,21 +44,29 @@ export default function Assignments() {
       title: "RELEASED",
       dataIndex: "published_date",
       key: "published_date",
-      render: text => text ? moment(text).format("MMM DD [AT] h:mmA").toUpperCase() : "None",
+      render: text => text
+  ? moment.tz(text, "UTC").tz("America/Chicago").format("MMM DD [AT] h:mmA").toUpperCase()
+  : "None",
+
       sorter: (a, b) => moment(a.published_date).unix() - moment(b.published_date).unix(),
     },
     {
       title: "DUE (CDT)",
       dataIndex: "due_date",
       key: "due_date",
-      render: text => text ? moment(text).format("MMM DD [AT] h:mmA").toUpperCase() : "None",
+      render: text => text
+  ? moment.tz(text, "UTC").tz("America/Chicago").format("MMM DD [AT] h:mmA").toUpperCase()
+  : "None",
+
       sorter: (a, b) => moment(a.due_date).unix() - moment(b.due_date).unix(),
     },
     {
       title: "LATE DUE (CDT)",
       dataIndex: "late_due_date",
       key: "late_due_date",
-      render: text => text ? moment(text).format("MMM DD [AT] h:mmA").toUpperCase() : "None",
+      render: text => text
+  ? moment.tz(text, "UTC").tz("America/Chicago").format("MMM DD [AT] h:mmA").toUpperCase()
+  : "None",
       sorter: (a, b) => moment(a.due_date).unix() - moment(b.due_date).unix(),
     },
   ];


### PR DESCRIPTION
When assignments were created, the backend stored times correctly in UTC. However, on the student portal assignment list, these timestamps were being interpreted incorrectly — causing them to shift by +6 hours for students. This resulted in students seeing wrong release & due times even though the instructor view showed correct times.

Now fixed student-side rendering by converting timestamps properly using the browser's local timezone when formatting. So now both instructor and student see the same correct time.