### PR TITLE
Update multi-provider AI settings for course and assignment feedback

### DIFF
--- a/backend/ai_integration.py
+++ b/backend/ai_integration.py
@@ -22,20 +22,41 @@ from api import db
 
 DEFAULT_MODEL = "gpt-4o-mini"
 DEFAULT_TEMPERATURE = 0.5
+GEMINI_MAX_OUTPUT_TOKENS = 1600
 CORRECTNESS_SYSTEM_PROMPT = (
     "You are an AI feedback assistant for programming assignments. "
-    "Give short, student-facing correctness and debugging hints only. "
-    "Do not comment on style, formatting, naming, indentation, readability, "
-    "organization, refactoring, or general best practices. "
+    "Give short, student-facing feedback about correctness, test results, "
+    "robustness, maintainability, and safe improvement opportunities. "
     "Do not provide corrected code, copy-paste fixes, or the full solution. "
     "Return only valid JSON."
 )
 DEFAULT_FEEDBACK_PROMPT = """
 You are giving short, student-facing feedback on a programming assignment.
 
-Your job is to help the student debug correctness problems without revealing the solution.
+Your goal is to help the student understand their submission quality, correctness, and possible improvements without revealing the full solution.
 
-Only give feedback that is directly related to whether the submitted program meets the assignment requirements or passes the tests.
+Always provide useful feedback, even if the submitted code passes all visible tests.
+
+Feedback should be professional, concise, and similar to feedback from a programming course autograder or Gradescope-style review.
+
+Required feedback sections:
+1. Overall Summary
+   - Briefly summarize whether the submission appears correct based on the test results and available code.
+   - If all tests pass, mention that no major correctness issue is obvious.
+
+2. Correctness Feedback
+   - Comment on failed tests, missing behavior, runtime errors, incorrect outputs, or edge cases.
+   - If there are no failed tests, say that the implementation appears to satisfy the tested requirements.
+
+3. Improvement Suggestions
+   - Give safe suggestions about robustness, edge cases, maintainability, or clarity.
+   - Suggestions should help the student improve without rewriting their code.
+
+4. Line Comments
+   - Add line-level comments only when a specific line or small code section is worth noting.
+   - Line comments can point out possible bugs, fragile logic, edge case risks, or useful improvements.
+   - Use a single-line code pattern for each annotation. Do not include newline characters in the pattern value.
+   - Do not force line comments if there is no meaningful line-specific feedback.
 
 Allowed feedback topics:
 - Incorrect logic
@@ -43,43 +64,41 @@ Allowed feedback topics:
 - Failed test cases
 - Edge cases
 - Runtime errors
-- Infinite loops
-- Incorrect input or output handling
+- Incorrect input/output handling
 - Incorrect return values
-- Incorrect state updates
-- Incorrect use of required algorithmic steps
-- Performance only if it causes timeout or failed tests
+- Algorithm mistakes
+- Robustness concerns
+- Maintainability concerns that could affect future correctness
+- Clear improvement suggestions
 
-Forbidden feedback topics:
-- Style
-- Formatting
-- Naming
-- Indentation
-- Readability
-- Code organization
-- Refactoring
-- General best practices that do not affect correctness
+Avoid:
+- Nitpicky formatting feedback
+- Pure style-only comments
+- Personal criticism
+- Rewriting the student's solution
+- Giving copy-paste fixes
+- Revealing the full answer
 
 Rules:
+- Keep the tone professional and encouraging.
 - Do not provide corrected code.
 - Do not give copy-paste fixes.
 - Do not reveal the final answer.
-- Do not explain how to fully solve the assignment.
-- Give hints that help the student investigate the bug.
-- Prefer comments tied to specific code patterns or failed behavior.
-- If the issue is based on test output, mention the symptom but not the full fix.
-- Keep each comment under 2 sentences.
-- If there are no clear correctness issues, return one insight saying no correctness issue is obvious from the available information.
+- Keep each comment short and specific.
+- If all tests pass, still provide an overall summary and at least one improvement or robustness suggestion when possible.
+- If no meaningful improvement is visible, say the submission appears solid based on the available tests.
 
 Return strictly valid JSON in this format:
 {
   "insights": [
-    "One short overall takeaway about the main correctness issue or debugging direction."
+    "Overall Summary: A short summary of the submission based on the code and tests.",
+    "Correctness Feedback: A short correctness-focused observation.",
+    "Improvement Suggestion: A safe suggestion about robustness, edge cases, maintainability, or clarity."
   ],
   "annotations": [
     {
       "pattern": "exact code snippet or recognizable code pattern from the student code",
-      "comment": "A short correctness-focused hint that helps the student debug without giving the answer."
+      "comment": "A short line-specific comment when a concrete code pattern is worth noting."
     }
   ]
 }
@@ -91,29 +110,35 @@ Return only valid JSON. Do not use markdown, code fences, bullet points, or extr
 Use this exact JSON structure:
 {
   "insights": [
-    "One short overall takeaway about the main correctness issue or debugging direction."
+    "Overall Summary: A short summary of the submission based on the code and tests.",
+    "Correctness Feedback: A short correctness-focused observation.",
+    "Improvement Suggestion: A safe suggestion about robustness, edge cases, maintainability, or clarity."
   ],
   "annotations": [
     {
       "pattern": "exact code snippet or recognizable code pattern from the student code",
-      "comment": "A short correctness-focused hint that helps the student debug without giving the answer."
+      "comment": "A short line-specific comment when a concrete code pattern is worth noting."
     }
   ]
 }
 
 Strict rules:
+- Include general insights for every submission.
+- Include annotations only when line-specific feedback is helpful.
+- Use a single-line code pattern for each annotation. Do not include newline characters in the pattern value.
 - Do not provide corrected code.
 - Do not give copy-paste fixes.
 - Do not reveal the final answer.
-- Do not comment on style, formatting, naming, indentation, readability, organization, or refactoring.
-- Do not make efficiency suggestions unless the submitted code times out or fails because of performance.
-- Only discuss correctness, logic, required behavior, edge cases, runtime errors, failed tests, input/output handling, or algorithmic mistakes.
-- Every annotation must connect to a concrete code pattern or observable failed behavior.
-- Keep each comment under 2 sentences.
-- If there are no clear correctness issues, return:
+- Keep each comment short and specific.
+- Discuss correctness, logic, required behavior, edge cases, runtime errors, failed tests, input/output handling, algorithmic mistakes, robustness, maintainability, or clarity.
+- Every annotation must connect to a concrete code pattern, observable failed behavior, edge case risk, or meaningful improvement opportunity.
+- Avoid nitpicky formatting feedback and pure style-only comments.
+- If there are no clear correctness issues, still return useful general insights, for example:
 {
   "insights": [
-    "No clear correctness issue is obvious from the available code and test results."
+    "Overall Summary: No clear correctness issue is obvious from the available code and test results.",
+    "Correctness Feedback: The implementation appears to satisfy the tested requirements.",
+    "Improvement Suggestion: Consider whether additional edge cases should be handled gracefully."
   ],
   "annotations": []
 }
@@ -192,7 +217,7 @@ def build_feedback_prompt(
 
 
 def clean_ai_response(text):
-    """Strips markdown formatting and unescapes newlines."""
+    """Strips markdown formatting while preserving valid JSON escapes."""
     if not text:
         return ""
 
@@ -204,8 +229,82 @@ def clean_ai_response(text):
     if lines and lines[-1].strip() == "```":
         lines = lines[:-1]
 
-    cleaned = "\n".join(lines).strip()
-    return cleaned.replace("\\n", "\n")
+    return "\n".join(lines).strip()
+
+
+def escape_control_chars_in_json_strings(text):
+    """Escapes literal control characters that providers sometimes put in JSON strings."""
+    result = []
+    in_string = False
+    escaped = False
+
+    for char in text:
+        if in_string:
+            if escaped:
+                result.append(char)
+                escaped = False
+            elif char == "\\":
+                result.append(char)
+                escaped = True
+            elif char == '"':
+                result.append(char)
+                in_string = False
+            elif char == "\n":
+                result.append("\\n")
+            elif char == "\r":
+                result.append("\\r")
+            elif char == "\t":
+                result.append("\\t")
+            elif ord(char) < 32:
+                result.append(f"\\u{ord(char):04x}")
+            else:
+                result.append(char)
+            continue
+
+        result.append(char)
+        if char == '"':
+            in_string = True
+
+    return "".join(result)
+
+
+def decode_feedback_candidate(candidate):
+    """Attempts to decode a JSON candidate, including repaired string controls."""
+    decoder = json.JSONDecoder()
+
+    for prepared_candidate in (
+        candidate,
+        escape_control_chars_in_json_strings(candidate),
+    ):
+        try:
+            return json.loads(prepared_candidate)
+        except json.JSONDecodeError:
+            pass
+
+        try:
+            parsed_json, _ = decoder.raw_decode(prepared_candidate)
+            return parsed_json
+        except json.JSONDecodeError:
+            pass
+
+    raise json.JSONDecodeError("Unable to decode feedback JSON", candidate, 0)
+
+
+def load_feedback_json(cleaned_response):
+    """Loads JSON, tolerating provider wrappers and unescaped string line breaks."""
+    try:
+        return decode_feedback_candidate(cleaned_response)
+    except json.JSONDecodeError:
+        for index, char in enumerate(cleaned_response):
+            if char not in "{[":
+                continue
+
+            try:
+                return decode_feedback_candidate(cleaned_response[index:])
+            except json.JSONDecodeError:
+                continue
+
+        raise
 
 
 def parse_feedback_json(raw_response, provider_name, past_insights):
@@ -213,7 +312,7 @@ def parse_feedback_json(raw_response, provider_name, past_insights):
     cleaned = clean_ai_response(raw_response)
 
     try:
-        parsed_json = json.loads(cleaned)
+        parsed_json = load_feedback_json(cleaned)
 
         if isinstance(parsed_json, str):
             parsed_json = json.loads(parsed_json)
@@ -234,6 +333,23 @@ def parse_feedback_json(raw_response, provider_name, past_insights):
             "error": f"Failed to parse {provider_name} response as JSON",
             "response_text": cleaned,
         }, past_insights
+
+
+def get_gemini_generation_config(model, temperature):
+    """Builds Gemini generation settings for complete JSON feedback."""
+    config = {
+        "temperature": temperature,
+        "maxOutputTokens": GEMINI_MAX_OUTPUT_TOKENS,
+        "responseMimeType": "application/json",
+    }
+
+    model_id = (model or "").lower()
+    if "gemini-2.5-flash" in model_id:
+        config["thinkingConfig"] = {"thinkingBudget": 0}
+    elif "gemini-2.5-pro" in model_id:
+        config["thinkingConfig"] = {"thinkingBudget": 128}
+
+    return config
 
 
 def get_structured_feedback_from_openai(client, prompt, model, temperature, past_insights):
@@ -276,11 +392,7 @@ def get_structured_feedback_from_gemini(api_key, prompt, model, temperature, pas
                     ],
                 }
             ],
-            "generationConfig": {
-                "temperature": temperature,
-                "maxOutputTokens": 700,
-                "responseMimeType": "application/json",
-            },
+            "generationConfig": get_gemini_generation_config(model, temperature),
         },
         timeout=30,
     )
@@ -289,11 +401,15 @@ def get_structured_feedback_from_gemini(api_key, prompt, model, temperature, pas
         raise ValueError(f"Gemini API error: {response.text}")
 
     data = response.json()
-    raw_response = (
-        data.get("candidates", [{}])[0]
-        .get("content", {})
-        .get("parts", [{}])[0]
-        .get("text", "")
+    candidate = data.get("candidates", [{}])[0]
+    finish_reason = candidate.get("finishReason")
+    if finish_reason:
+        print(f"AI_FEEDBACK: Gemini finishReason={finish_reason}", flush=True)
+
+    raw_response = "".join(
+        part.get("text", "")
+        for part in candidate.get("content", {}).get("parts", [])
+        if not part.get("thought")
     )
 
     return parse_feedback_json(raw_response, "Gemini", past_insights)

--- a/backend/ai_integration.py
+++ b/backend/ai_integration.py
@@ -1,94 +1,130 @@
 import os
-from openai import OpenAI
-from cryptography.fernet import Fernet
-from dotenv import load_dotenv
-from util.errors import InternalProcessingError, NotFoundError
-from api.models import Assignment, Submission, User, Course
-from api import db
-
 import subprocess
-import os
 import hashlib
-import docker 
+import docker
 import zipfile
 import shutil
 import time
-from dotenv import load_dotenv
-from openai import OpenAI
 import threading
-from sqlalchemy.orm import aliased
 import json
+import requests
 
+from openai import OpenAI
+from cryptography.fernet import Fernet
+from dotenv import load_dotenv
+from sqlalchemy.orm import aliased
+
+from util.errors import InternalProcessingError, NotFoundError
 from util.encryption_utils import decrypt_api_key
+from api.models import Assignment, Submission, User, Course
+from api import db
 
 
-DEFAULT_MODEL="gpt-4-turbo"
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_TEMPERATURE = 0.5
+CORRECTNESS_SYSTEM_PROMPT = (
+    "You are an AI feedback assistant for programming assignments. "
+    "Give short, student-facing correctness and debugging hints only. "
+    "Do not comment on style, formatting, naming, indentation, readability, "
+    "organization, refactoring, or general best practices. "
+    "Do not provide corrected code, copy-paste fixes, or the full solution. "
+    "Return only valid JSON."
+)
 DEFAULT_FEEDBACK_PROMPT = """
-You are giving short, student-facing feedback on a coding assignment.
+You are giving short, student-facing feedback on a programming assignment.
 
-Your goal is to help students write better code without giving away the full solution.
+Your job is to help the student debug correctness problems without revealing the solution.
+
+Only give feedback that is directly related to whether the submitted program meets the assignment requirements or passes the tests.
+
+Allowed feedback topics:
+- Incorrect logic
+- Missing required behavior
+- Failed test cases
+- Edge cases
+- Runtime errors
+- Infinite loops
+- Incorrect input or output handling
+- Incorrect return values
+- Incorrect state updates
+- Incorrect use of required algorithmic steps
+- Performance only if it causes timeout or failed tests
+
+Forbidden feedback topics:
+- Style
+- Formatting
+- Naming
+- Indentation
+- Readability
+- Code organization
+- Refactoring
+- General best practices that do not affect correctness
 
 Rules:
 - Do not provide corrected code.
 - Do not give copy-paste fixes.
-- Give short hints, not full answers.
-- Focus on code quality, debugging, edge cases, readability, and error handling.
+- Do not reveal the final answer.
+- Do not explain how to fully solve the assignment.
+- Give hints that help the student investigate the bug.
+- Prefer comments tied to specific code patterns or failed behavior.
+- If the issue is based on test output, mention the symptom but not the full fix.
 - Keep each comment under 2 sentences.
-- Use encouraging, clear language.
-- Prefer guiding questions when possible.
+- If there are no clear correctness issues, return one insight saying no correctness issue is obvious from the available information.
 
 Return strictly valid JSON in this format:
 {
   "insights": [
-    "One short overall takeaway about how the student can improve."
+    "One short overall takeaway about the main correctness issue or debugging direction."
   ],
   "annotations": [
     {
-      "pattern": "exact code snippet or recognizable code pattern",
-      "category": "Correctness | Edge Case | Error Handling | Readability | Efficiency | Style",
-      "hint": "A short hint that helps the student improve without giving the answer.",
-      "why_it_matters": "One short reason this matters."
+      "pattern": "exact code snippet or recognizable code pattern from the student code",
+      "comment": "A short correctness-focused hint that helps the student debug without giving the answer."
     }
   ]
 }
 """
 
-DEFAULT_TEMPERATURE=0.5
 RETURN_SPEC = """
-Return only valid JSON. Do not use markdown, code fences, or extra explanation.
+Return only valid JSON. Do not use markdown, code fences, bullet points, or extra explanation.
 
 Use this exact JSON structure:
 {
   "insights": [
-    "One short overall takeaway about how the student can improve."
+    "One short overall takeaway about the main correctness issue or debugging direction."
   ],
   "annotations": [
     {
-      "pattern": "exact code snippet or recognizable code pattern",
-      "comment": "A short student-facing hint that helps the student improve without giving the answer."
+      "pattern": "exact code snippet or recognizable code pattern from the student code",
+      "comment": "A short correctness-focused hint that helps the student debug without giving the answer."
     }
   ]
 }
 
-Rules:
+Strict rules:
 - Do not provide corrected code.
 - Do not give copy-paste fixes.
+- Do not reveal the final answer.
+- Do not comment on style, formatting, naming, indentation, readability, organization, or refactoring.
+- Do not make efficiency suggestions unless the submitted code times out or fails because of performance.
+- Only discuss correctness, logic, required behavior, edge cases, runtime errors, failed tests, input/output handling, or algorithmic mistakes.
+- Every annotation must connect to a concrete code pattern or observable failed behavior.
 - Keep each comment under 2 sentences.
-- Make feedback helpful for improving code quality, debugging, edge cases, readability, and error handling.
-- Use hints and guiding questions instead of direct answers.
+- If there are no clear correctness issues, return:
+{
+  "insights": [
+    "No clear correctness issue is obvious from the available code and test results."
+  ],
+  "annotations": []
+}
 """
 
-# Load environment variables
 load_dotenv()
 
-# Load encryption key for decrypting API key
 SECRET_KEY = os.getenv("API_SECRET_KEY")
 cipher = Fernet(SECRET_KEY) if SECRET_KEY else None
 
-# --- helper functions for getting AI feedback ---
 
-# Function to fetch related submission, assignment, course, and student records from DB
-#  returns a tuple of (submission, assignment, course, student)
 def fetch_submission_data(submission_id):
     """Fetch related submission, assignment, course, and student records from DB."""
     assignment_alias = aliased(Assignment)
@@ -106,13 +142,45 @@ def fetch_submission_data(submission_id):
 
     if result:
         return result
-    else:
-        raise ValueError(f"Submission ID {submission_id} not found")
 
-def build_feedback_prompt(base_prompt, past_insights, code, autograder_results):
+    raise ValueError(f"Submission ID {submission_id} not found")
+def get_feedback_style_instruction(assignment, course):
+    """Return prompt instruction based on selected feedback style."""
+    style = (
+        getattr(assignment, "ai_feedback_style", None)
+        or getattr(course, "default_feedback_style", None)
+        or "balanced"
+    )
+
+    style = style.lower()
+
+    if style == "hint-based":
+        return (
+            "Feedback style: hint-based. Give indirect debugging hints or guiding questions. "
+            "Do not identify the exact fix."
+        )
+
+    if style == "detailed-debugging":
+        return (
+            "Feedback style: detailed debugging. Give slightly more explanation about the likely correctness issue, "
+            "what behavior to test, and what part of the code to inspect. Still do not provide corrected code."
+        )
+
+    return (
+        "Feedback style: balanced. Give concise correctness-focused feedback with enough context to guide debugging."
+    )
+
+def build_feedback_prompt(
+    base_prompt,
+    past_insights,
+    code,
+    autograder_results,
+    style_instruction,
+):
     """Constructs the full prompt sent to the AI model."""
     return (
         f"{base_prompt or DEFAULT_FEEDBACK_PROMPT}\n\n"
+        f"{style_instruction}\n\n"
         f"{RETURN_SPEC}\n\n"
         "Past student insights:\n"
         f"{past_insights}\n\n"
@@ -122,11 +190,50 @@ def build_feedback_prompt(base_prompt, past_insights, code, autograder_results):
         f"{autograder_results}\n\n"
     )
 
-def format_message(text, model="gpt-4o"):
-    """Formats messages depending on the OpenAI model being used."""
-    if "gpt-4o" in model:
-        return [{ "type": "text", "text": str(text) }]
-    return text
+
+def clean_ai_response(text):
+    """Strips markdown formatting and unescapes newlines."""
+    if not text:
+        return ""
+
+    lines = text.splitlines()
+
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+
+    cleaned = "\n".join(lines).strip()
+    return cleaned.replace("\\n", "\n")
+
+
+def parse_feedback_json(raw_response, provider_name, past_insights):
+    """Parses model output into JSON feedback."""
+    cleaned = clean_ai_response(raw_response)
+
+    try:
+        parsed_json = json.loads(cleaned)
+
+        if isinstance(parsed_json, str):
+            parsed_json = json.loads(parsed_json)
+
+        print("AI_FEEDBACK:")
+        print(json.dumps(parsed_json, indent=4), flush=True)
+
+        return parsed_json, parsed_json.get("insights", [])
+
+    except Exception as e:
+        print(
+            f"AI_FEEDBACK: Failed to parse {provider_name} JSON response: {e}",
+            flush=True,
+        )
+        print(f"AI_FEEDBACK RAW RESPONSE: {cleaned}", flush=True)
+
+        return {
+            "error": f"Failed to parse {provider_name} response as JSON",
+            "response_text": cleaned,
+        }, past_insights
 
 
 def get_structured_feedback_from_openai(client, prompt, model, temperature, past_insights):
@@ -135,58 +242,111 @@ def get_structured_feedback_from_openai(client, prompt, model, temperature, past
         messages=[
             {
                 "role": "system",
-                "content": "You are an AI that gives short, student-facing coding hints. Return only valid JSON."
+                "content": CORRECTNESS_SYSTEM_PROMPT,
             },
             {
                 "role": "user",
-                "content": prompt
-            }
+                "content": prompt,
+            },
         ],
         model=model,
         max_tokens=700,
         temperature=temperature,
         timeout=30,
-        response_format={"type": "json_object"}
+        response_format={"type": "json_object"},
     )
 
     raw_response = response.choices[0].message.content.strip()
-    cleaned = clean_ai_response(raw_response)
+    return parse_feedback_json(raw_response, "OpenAI", past_insights)
 
-    try:
-        parsed_json = json.loads(cleaned)
-        if isinstance(parsed_json, str):
-            parsed_json = json.loads(parsed_json)
 
-        print("AI_FEEDBACK:")
-        print(json.dumps(parsed_json, indent=4), flush=True)
+def get_structured_feedback_from_gemini(api_key, prompt, model, temperature, past_insights):
+    """Sends request to Gemini and parses JSON feedback."""
+    response = requests.post(
+        f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+        params={"key": api_key},
+        json={
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "text": f"{CORRECTNESS_SYSTEM_PROMPT}\n\n{prompt}"
+                        }
+                    ],
+                }
+            ],
+            "generationConfig": {
+                "temperature": temperature,
+                "maxOutputTokens": 700,
+                "responseMimeType": "application/json",
+            },
+        },
+        timeout=30,
+    )
 
-        return parsed_json, parsed_json.get("insights", [])
-    except Exception as e:
-        print(f"AI_FEEDBACK: Failed to parse JSON from response: {e}", flush=True)
-        print(f"AI_FEEDBACK RAW RESPONSE: {cleaned}", flush=True)
+    if response.status_code >= 400:
+        raise ValueError(f"Gemini API error: {response.text}")
 
-        return {
-            "error": "Failed to parse OpenAI response as JSON",
-            "response_text": cleaned
-        }, past_insights
+    data = response.json()
+    raw_response = (
+        data.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text", "")
+    )
 
-def clean_ai_response(text):
-    """Strips markdown formatting and unescapes newlines."""
-    lines = text.splitlines()
+    return parse_feedback_json(raw_response, "Gemini", past_insights)
 
-    if lines and lines[0].startswith("```"):
-        lines = lines[1:]
-    if lines and lines[-1].strip() == "```":
-        lines = lines[:-1]
 
-    cleaned = "\n".join(lines).strip()
-    return cleaned.replace("\\n", "\n")
+def get_structured_feedback_from_claude(api_key, prompt, model, temperature, past_insights):
+    """Sends request to Claude and parses JSON feedback."""
+    response = requests.post(
+        "https://api.anthropic.com/v1/messages",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        json={
+            "model": model,
+            "max_tokens": 700,
+            "temperature": temperature,
+            "system": CORRECTNESS_SYSTEM_PROMPT,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+        },
+        timeout=30,
+    )
+
+    if response.status_code >= 400:
+        raise ValueError(f"Claude API error: {response.text}")
+
+    data = response.json()
+    content = data.get("content", [])
+
+    raw_response = ""
+    if content and content[0].get("type") == "text":
+        raw_response = content[0].get("text", "")
+
+    return parse_feedback_json(raw_response, "Claude", past_insights)
 
 
 def update_submission_feedback(submission_id, ai_feedback_json, new_insights):
     """Updates the database with the AI feedback and new student insights."""
     submission = Submission.query.get(submission_id)
+
+    if not submission:
+        raise ValueError(f"Submission ID {submission_id} not found")
+
     student = User.query.get(submission.student_id)
+
+    if not student:
+        raise ValueError(f"Student ID {submission.student_id} not found")
 
     submission.ai_feedback = json.dumps(ai_feedback_json)
     student.coding_insights = str(new_insights)
@@ -194,16 +354,109 @@ def update_submission_feedback(submission_id, ai_feedback_json, new_insights):
     db.session.commit()
 
 
+def get_provider_and_model(assignment, course):
+    """Chooses provider/model from course default or assignment override."""
+    if getattr(assignment, "use_course_ai_default", True):
+        provider = course.default_ai_provider or "openai"
+        model = course.default_ai_model or DEFAULT_MODEL
+    else:
+        provider = (
+            assignment.ai_feedback_provider
+            or course.default_ai_provider
+            or "openai"
+        )
+        model = (
+            assignment.ai_feedback_model
+            or course.default_ai_model
+            or DEFAULT_MODEL
+        )
 
-# Define a background task for obtaining and recording AI feedback.
+    return provider, model
+
+
+def get_temperature(assignment, course):
+    """Chooses assignment temperature, course temperature, or default."""
+    try:
+        return float(
+            assignment.ai_feedback_temperature
+            or course.default_ai_temperature
+            or DEFAULT_TEMPERATURE
+        )
+    except (TypeError, ValueError):
+        return DEFAULT_TEMPERATURE
+
+
+def get_provider_credentials(provider, course):
+    """Returns API key and OpenAI client if needed."""
+    api_key = None
+    client = None
+
+    if provider == "openai":
+        if not course.openai_api_key:
+            raise ValueError("Missing OpenAI API key for this course")
+
+        api_key = decrypt_api_key(course.openai_api_key)
+        client = OpenAI(api_key=api_key)
+
+    elif provider == "gemini":
+        if not course.gemini_api_key:
+            raise ValueError("Missing Gemini API key for this course")
+
+        api_key = decrypt_api_key(course.gemini_api_key)
+
+    elif provider == "claude":
+        if not course.claude_api_key:
+            raise ValueError("Missing Claude API key for this course")
+
+        api_key = decrypt_api_key(course.claude_api_key)
+
+    else:
+        raise ValueError(f"Unsupported AI provider: {provider}")
+
+    return api_key, client
+
+
+def get_feedback_by_provider(provider, api_key, client, prompt, model, temperature, past_insights):
+    """Calls the selected AI provider."""
+    if provider == "openai":
+        return get_structured_feedback_from_openai(
+            client,
+            prompt,
+            model,
+            temperature,
+            past_insights,
+        )
+
+    if provider == "gemini":
+        return get_structured_feedback_from_gemini(
+            api_key,
+            prompt,
+            model,
+            temperature,
+            past_insights,
+        )
+
+    if provider == "claude":
+        return get_structured_feedback_from_claude(
+            api_key,
+            prompt,
+            model,
+            temperature,
+            past_insights,
+        )
+
+    raise ValueError(f"Unsupported AI provider: {provider}")
+
+
 def async_get_ai_feedback(app, submission_id, file_path, results_json_content):
+    """Background task for obtaining and recording AI feedback."""
     ctx = app.app_context()
     ctx.push()
 
     try:
         print(f"AI_FEEDBACK: Starting for submission {submission_id}", flush=True)
 
-        with open(file_path, 'r') as code_file:
+        with open(file_path, "r") as code_file:
             code_text = code_file.read()
 
         print("AI_FEEDBACK: Code file loaded", flush=True)
@@ -212,7 +465,7 @@ def async_get_ai_feedback(app, submission_id, file_path, results_json_content):
 
         print(
             f"AI_FEEDBACK: Loaded DB records. enabled={assignment.ai_feedback_enabled}",
-            flush=True
+            flush=True,
         )
 
         if not assignment.ai_feedback_enabled:
@@ -220,33 +473,38 @@ def async_get_ai_feedback(app, submission_id, file_path, results_json_content):
             return
 
         past_insights = student.coding_insights or "No prior insights."
-        base_prompt = assignment.ai_feedback_prompt or DEFAULT_FEEDBACK_PROMPT
-        model = assignment.ai_feedback_model or DEFAULT_MODEL
 
-        try:
-            temperature = float(assignment.ai_feedback_temperature or DEFAULT_TEMPERATURE)
-        except (TypeError, ValueError):
-            temperature = DEFAULT_TEMPERATURE
+        custom_prompt = (assignment.ai_feedback_prompt or "").strip()
+        base_prompt = custom_prompt if custom_prompt else DEFAULT_FEEDBACK_PROMPT
+        style_instruction = get_feedback_style_instruction(assignment, course)
 
-        if not course.openai_api_key:
-            raise ValueError("Missing OpenAI API key for this course")
+        provider, model = get_provider_and_model(assignment, course)
+        temperature = get_temperature(assignment, course)
+        api_key, client = get_provider_credentials(provider, course)
 
-        print(f"AI_FEEDBACK: Using model={model}, temperature={temperature}", flush=True)
-
-        decrypted_api_key = decrypt_api_key(course.openai_api_key)
-        client = OpenAI(api_key=decrypted_api_key)
+        print(
+            f"AI_FEEDBACK: Using provider={provider}, model={model}, temperature={temperature}",
+            flush=True,
+        )
 
         prompt = build_feedback_prompt(
             base_prompt,
             past_insights,
             code_text,
-            results_json_content
+            results_json_content,
+            style_instruction,
         )
 
-        print("AI_FEEDBACK: Calling OpenAI", flush=True)
+        print(f"AI_FEEDBACK: Calling {provider}", flush=True)
 
-        ai_feedback_json, new_insights = get_structured_feedback_from_openai(
-            client, prompt, model, temperature, past_insights
+        ai_feedback_json, new_insights = get_feedback_by_provider(
+            provider,
+            api_key,
+            client,
+            prompt,
+            model,
+            temperature,
+            past_insights,
         )
 
         print("AI_FEEDBACK: Updating submission feedback", flush=True)
@@ -257,6 +515,32 @@ def async_get_ai_feedback(app, submission_id, file_path, results_json_content):
 
     except Exception as e:
         print(f"AI_FEEDBACK: Unexpected error - {type(e).__name__}: {e}", flush=True)
+
+        try:
+            submission = Submission.query.get(submission_id)
+
+            if submission:
+                submission.ai_feedback = json.dumps({
+                    "error": f"AI feedback generation failed: {type(e).__name__}: {e}",
+                    "insights": [
+                        "AI feedback could not be generated for this submission. Please review the submission manually."
+                    ],
+                    "annotations": []
+                })
+
+                db.session.commit()
+
+                print(
+                    f"AI_FEEDBACK: Saved failure feedback for submission {submission_id}",
+                    flush=True,
+                )
+
+        except Exception as save_error:
+            db.session.rollback()
+            print(
+                f"AI_FEEDBACK: Failed to save error feedback - {type(save_error).__name__}: {save_error}",
+                flush=True,
+            )
 
     finally:
         ctx.pop()

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -28,7 +28,15 @@ class Course(db.Model):
     description = db.Column(db.String, default="")
 
     # -- AI Integration Settings -- 
+    default_ai_provider = db.Column(db.String, default="openai")
+    default_ai_model = db.Column(db.String, default="gpt-4o-mini")
+
     openai_api_key = db.Column(db.String, default="")
+    gemini_api_key = db.Column(db.String, default="")
+    claude_api_key = db.Column(db.String, default="")
+
+    default_feedback_style = db.Column(db.String, default="hint-based")
+    default_ai_temperature = db.Column(db.Float, default=0.5)
 
 @dataclass
 class Enrollment(db.Model):
@@ -58,11 +66,14 @@ class Assignment(db.Model):
     autograder_image_name = db.Column(db.String)
     autograder_timeout = db.Column(db.Integer, default=300)
 
-    # -- AI Integration Settings -- 
+    # -- AI Integration Settings --
     ai_feedback_enabled = db.Column(db.Boolean, default=False)
+    use_course_ai_default = db.Column(db.Boolean, default=True)
+    ai_feedback_provider = db.Column(db.String, nullable=True)
+    ai_feedback_model = db.Column(db.String, nullable=True)
     ai_feedback_prompt = db.Column(db.Text, nullable=True)
-    ai_feedback_model = db.Column(db.Text, nullable=True)
     ai_feedback_temperature = db.Column(db.Float, nullable=True)
+    ai_feedback_style = db.Column(db.String, nullable=True)
 
 class Submission(db.Model):
     __tablename__ = "submissions"

--- a/backend/migrations/versions/a1b2c3d4e5f6_add_ai_settings_fields.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_add_ai_settings_fields.py
@@ -1,0 +1,51 @@
+"""Add AI settings fields.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 92009ca5c92a
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "92009ca5c92a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS default_ai_provider VARCHAR DEFAULT 'openai'")
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS default_ai_model VARCHAR DEFAULT 'gpt-4o-mini'")
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS openai_api_key VARCHAR DEFAULT ''")
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS gemini_api_key VARCHAR DEFAULT ''")
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS claude_api_key VARCHAR DEFAULT ''")
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS default_feedback_style VARCHAR DEFAULT 'hint-based'")
+    op.execute("ALTER TABLE courses ADD COLUMN IF NOT EXISTS default_ai_temperature FLOAT DEFAULT 0.5")
+
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS ai_feedback_enabled BOOLEAN DEFAULT FALSE")
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS use_course_ai_default BOOLEAN DEFAULT TRUE")
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS ai_feedback_provider VARCHAR")
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS ai_feedback_model VARCHAR")
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS ai_feedback_prompt TEXT")
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS ai_feedback_temperature FLOAT")
+    op.execute("ALTER TABLE assignments ADD COLUMN IF NOT EXISTS ai_feedback_style VARCHAR")
+
+
+def downgrade():
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS ai_feedback_style")
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS ai_feedback_temperature")
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS ai_feedback_prompt")
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS ai_feedback_model")
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS ai_feedback_provider")
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS use_course_ai_default")
+    op.execute("ALTER TABLE assignments DROP COLUMN IF EXISTS ai_feedback_enabled")
+
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS default_ai_temperature")
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS default_feedback_style")
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS claude_api_key")
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS gemini_api_key")
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS openai_api_key")
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS default_ai_model")
+    op.execute("ALTER TABLE courses DROP COLUMN IF EXISTS default_ai_provider")

--- a/backend/routes/course.py
+++ b/backend/routes/course.py
@@ -28,18 +28,35 @@ def is_supported_openai_model(model_id):
     """
     Filter OpenAI models shown in the dropdown.
 
-    Remove o-series models that fail with the current test request because
-    they do not support max_tokens in the chat completions call.
+    Keep standard text chat models that work with this app's chat completion
+    request shape. Remove o-series and special-purpose models that may appear
+    in the models API but fail with max_tokens, response_format, or text-only
+    chat completions.
     """
-    blocked_models = {
-        "o3-mini",
-        "o4-mini",
-    }
+    normalized_model_id = (model_id or "").lower()
+    blocked_prefixes = ("o1", "o3", "o4")
+    blocked_keywords = [
+        "audio",
+        "dall-e",
+        "embedding",
+        "image",
+        "instruct",
+        "moderation",
+        "preview",
+        "realtime",
+        "search",
+        "transcribe",
+        "tts",
+        "whisper",
+    ]
 
-    if model_id in blocked_models:
+    if normalized_model_id.startswith(blocked_prefixes):
         return False
 
-    return model_id.startswith("gpt-")
+    if any(keyword in normalized_model_id for keyword in blocked_keywords):
+        return False
+
+    return normalized_model_id.startswith("gpt-")
 
 
 def is_supported_gemini_model(model_id):
@@ -60,6 +77,9 @@ def is_supported_gemini_model(model_id):
         "learnlm",
         "deep-research",
         "antigravity",
+        "preview",
+        "exp",
+        "experimental",
     ]
 
     blocked_models = {

--- a/backend/routes/course.py
+++ b/backend/routes/course.py
@@ -1,6 +1,7 @@
 import uuid
 import os
 import csv
+import requests
 from flask import Blueprint, request, jsonify
 from flask_cors import cross_origin
 from werkzeug.utils import secure_filename
@@ -15,13 +16,96 @@ from api.models import (
 )
 from api.schemas import AssignmentSchema, CourseSchema, EnrollmentSchema, UserSchema
 from util.errors import BadRequestError, InternalProcessingError, ConflictError, NotFoundError, ForbiddenError
-from util.encryption_utils import encrypt_api_key
+from util.encryption_utils import encrypt_api_key, decrypt_api_key
+from openai import OpenAI
 
 course = Blueprint("course", __name__)
 
 ALLOWED_EXTENSIONS = {'csv'}
 UPLOAD_FOLDER = 'uploads'
 
+def is_supported_openai_model(model_id):
+    """
+    Filter OpenAI models shown in the dropdown.
+
+    Remove o-series models that fail with the current test request because
+    they do not support max_tokens in the chat completions call.
+    """
+    blocked_models = {
+        "o3-mini",
+        "o4-mini",
+    }
+
+    if model_id in blocked_models:
+        return False
+
+    return model_id.startswith("gpt-")
+
+
+def is_supported_gemini_model(model_id):
+    """
+    Filter Gemini models shown in the dropdown.
+
+    Keep normal Gemini text generation models.
+    Remove research, antigravity, embedding, audio, image, and other special models.
+    """
+    blocked_keywords = [
+        "embedding",
+        "aqa",
+        "imagen",
+        "veo",
+        "tts",
+        "native-audio",
+        "live",
+        "learnlm",
+        "deep-research",
+        "antigravity",
+    ]
+
+    blocked_models = {
+        "gemini-2.0-flash",
+    }
+
+    if model_id in blocked_models:
+        return False
+
+    if any(keyword in model_id.lower() for keyword in blocked_keywords):
+        return False
+
+    return model_id.startswith("gemini-")
+
+
+def is_supported_claude_model(model_id):
+    """
+    Filter Claude models shown in the dropdown.
+
+    Remove known unavailable or special-access Claude models.
+    """
+    blocked_keywords = [
+        "fable",
+        "mythos",
+    ]
+
+    if any(keyword in model_id.lower() for keyword in blocked_keywords):
+        return False
+
+    return model_id.startswith("claude-")
+
+def get_plain_api_key(encrypted_key):
+    """
+    Returns decrypted API key for the frontend password input.
+
+    This allows the UI to keep the saved key hidden by default,
+    while still allowing the user to reveal it with the visibility icon.
+    """
+    if not encrypted_key:
+        return ""
+
+    try:
+        return decrypt_api_key(encrypted_key)
+    except Exception:
+        return ""
+    
 @course.route("/create_course", methods=["POST", "GET"])
 @cross_origin()
 def create_course():
@@ -468,6 +552,7 @@ def get_course_assignments():
 
     return jsonify(assignments), 200
 
+
 @course.route("/get_course_info", methods=["GET"])
 @cross_origin()
 def get_course_info():
@@ -476,12 +561,33 @@ def get_course_info():
     if not course_id or course_id == "":
         raise BadRequestError("Missing course_id argument")
 
-    course = db.session.query(Course).filter_by(id=course_id)
-    course = CourseSchema().dump(course, many=True)
+    course_obj = db.session.query(Course).filter_by(id=course_id).first()
 
-    return jsonify(course), 200
+    if not course_obj:
+        raise NotFoundError("Course not found")
+
+    course_data = CourseSchema().dump(course_obj)
+
+    course_data.update({
+        "default_ai_provider": course_obj.default_ai_provider,
+        "default_ai_model": course_obj.default_ai_model,
+        "default_feedback_style": course_obj.default_feedback_style,
+        "default_ai_temperature": course_obj.default_ai_temperature,
+
+        "has_openai_api_key": bool(course_obj.openai_api_key),
+        "has_gemini_api_key": bool(course_obj.gemini_api_key),
+        "has_claude_api_key": bool(course_obj.claude_api_key),
+
+        "openai_api_key_value": get_plain_api_key(course_obj.openai_api_key),
+        "gemini_api_key_value": get_plain_api_key(course_obj.gemini_api_key),
+        "claude_api_key_value": get_plain_api_key(course_obj.claude_api_key),
+    })
+
+    return jsonify([course_data]), 200
 
 @course.route("/store_api_key", methods=["PUT"])
+@cross_origin()
+
 def store_api_key():
     """
     /store_api_key stores an encrypted OpenAI API key for a course.
@@ -511,6 +617,443 @@ def store_api_key():
         db.session.rollback()
         raise InternalProcessingError("Failed to store API key")
 
+@course.route("/update_ai_settings", methods=["PUT"])
+@cross_origin()
+def update_ai_settings():
+    data = request.json
+
+    course_id = data.get("course_id")
+    provider = data.get("provider")
+    model_name = data.get("model_name")
+    api_key = data.get("api_key")
+    feedback_style = data.get("feedback_style")
+    temperature = data.get("temperature")
+
+    if not course_id:
+        raise BadRequestError("Missing course_id")
+
+    course_obj = db.session.query(Course).filter_by(id=course_id).first()
+
+    if not course_obj:
+        raise NotFoundError("Course not found")
+
+    if provider:
+        course_obj.default_ai_provider = provider
+
+    if model_name:
+        course_obj.default_ai_model = model_name
+
+    if feedback_style:
+        course_obj.default_feedback_style = feedback_style
+
+    if temperature is not None:
+        try:
+            course_obj.default_ai_temperature = float(temperature)
+        except (TypeError, ValueError):
+            raise BadRequestError("Invalid temperature")
+
+    if api_key:
+        if not provider:
+            raise BadRequestError("Missing provider for API key")
+
+        encrypted_api_key = encrypt_api_key(api_key)
+
+        if provider == "openai":
+            course_obj.openai_api_key = encrypted_api_key
+        elif provider == "gemini":
+            course_obj.gemini_api_key = encrypted_api_key
+        elif provider == "claude":
+            course_obj.claude_api_key = encrypted_api_key
+        else:
+            raise BadRequestError("Unsupported AI provider")
+
+    try:
+        db.session.commit()
+        return jsonify({"message": "AI settings updated successfully"}), 200
+    except Exception:
+        db.session.rollback()
+        raise InternalProcessingError("Failed to update AI settings")
+
+
+@course.route("/fetch_ai_models", methods=["POST"])
+@cross_origin()
+def fetch_ai_models():
+    data = request.json
+
+    course_id = data.get("course_id")
+    provider = data.get("provider")
+    api_key = data.get("api_key")
+
+    if not provider:
+        raise BadRequestError("Missing provider")
+
+    try:
+        if not api_key:
+            if not course_id:
+                raise BadRequestError("Missing course_id or api_key")
+
+            course_obj = db.session.query(Course).filter_by(id=course_id).first()
+
+            if not course_obj:
+                raise NotFoundError("Course not found")
+
+            if provider == "openai" and course_obj.openai_api_key:
+                api_key = decrypt_api_key(course_obj.openai_api_key)
+            elif provider == "gemini" and course_obj.gemini_api_key:
+                api_key = decrypt_api_key(course_obj.gemini_api_key)
+            elif provider == "claude" and course_obj.claude_api_key:
+                api_key = decrypt_api_key(course_obj.claude_api_key)
+            else:
+                raise BadRequestError(f"No saved API key for {provider}")
+
+        if provider == "openai":
+            client = OpenAI(api_key=api_key)
+            models_response = client.models.list()
+
+            model_ids = [
+                model.id
+                for model in models_response.data
+                if is_supported_openai_model(model.id)
+            ]
+
+            preferred_order = [
+                "gpt-4o-mini",
+                "gpt-4o",
+                "gpt-4.1-mini",
+                "gpt-4.1",
+            ]
+
+            sorted_models = sorted(
+                set(model_ids),
+                key=lambda model: (
+                    preferred_order.index(model)
+                    if model in preferred_order
+                    else len(preferred_order),
+                    model
+                )
+            )
+
+            return jsonify({"models": sorted_models}), 200
+
+        if provider == "gemini":
+            response = requests.get(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                params={"key": api_key},
+                timeout=30,
+            )
+
+            if response.status_code >= 400:
+                return jsonify({"error": response.text}), response.status_code
+
+            models_data = response.json().get("models", [])
+
+            model_ids = []
+            for model in models_data:
+                model_name = model.get("name", "").replace("models/", "")
+                supported_methods = model.get("supportedGenerationMethods", [])
+
+                if (
+                    "generateContent" in supported_methods
+                    and is_supported_gemini_model(model_name)
+                ):
+                    model_ids.append(model_name)
+
+            preferred_order = [
+                "gemini-1.5-flash",
+                "gemini-1.5-pro",
+                "gemini-2.5-flash",
+                "gemini-2.5-pro",
+            ]
+
+            sorted_models = sorted(
+                set(model_ids),
+                key=lambda model: (
+                    preferred_order.index(model)
+                    if model in preferred_order
+                    else len(preferred_order),
+                    model
+                )
+            )
+
+            return jsonify({"models": sorted_models}), 200
+
+        if provider == "claude":
+            response = requests.get(
+                "https://api.anthropic.com/v1/models",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                },
+                timeout=30,
+            )
+
+            if response.status_code >= 400:
+                return jsonify({"error": response.text}), response.status_code
+
+            models_data = response.json().get("data", [])
+
+            model_ids = [
+                model.get("id")
+                for model in models_data
+                if model.get("id") and is_supported_claude_model(model.get("id"))
+            ]
+
+            preferred_order = [
+                "claude-3-5-sonnet-20241022",
+                "claude-3-5-haiku-20241022",
+                "claude-3-opus-20240229",
+                "claude-3-5-sonnet-latest",
+                "claude-3-5-haiku-latest",
+                "claude-3-opus-latest",
+            ]
+
+            sorted_models = sorted(
+                set(model_ids),
+                key=lambda model: (
+                    preferred_order.index(model)
+                    if model in preferred_order
+                    else len(preferred_order),
+                    model
+                )
+            )
+
+            return jsonify({"models": sorted_models}), 200
+
+        raise BadRequestError("Unsupported AI provider")
+
+    except (BadRequestError, NotFoundError):
+        raise
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+@course.route("/test_ai_api_key", methods=["POST"])
+@cross_origin()
+def test_ai_api_key():
+    data = request.json
+
+    course_id = data.get("course_id")
+    provider = data.get("provider")
+    api_key = data.get("api_key")
+
+    if not provider:
+        raise BadRequestError("Missing provider")
+
+    try:
+        if not api_key:
+            if not course_id:
+                raise BadRequestError("Missing course_id or api_key")
+
+            course_obj = db.session.query(Course).filter_by(id=course_id).first()
+
+            if not course_obj:
+                raise NotFoundError("Course not found")
+
+            if provider == "openai" and course_obj.openai_api_key:
+                api_key = decrypt_api_key(course_obj.openai_api_key)
+            elif provider == "gemini" and course_obj.gemini_api_key:
+                api_key = decrypt_api_key(course_obj.gemini_api_key)
+            elif provider == "claude" and course_obj.claude_api_key:
+                api_key = decrypt_api_key(course_obj.claude_api_key)
+            else:
+                raise BadRequestError(f"No saved API key for {provider}")
+
+        if provider == "openai":
+            client = OpenAI(api_key=api_key)
+            client.models.list()
+
+            return jsonify({
+                "message": "OpenAI API key is valid",
+                "provider": provider,
+            }), 200
+
+        if provider == "gemini":
+            response = requests.get(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                params={"key": api_key},
+                timeout=30,
+            )
+
+            if response.status_code >= 400:
+                return jsonify({
+                    "error": f"Gemini API key test failed: {response.text}"
+                }), response.status_code
+
+            return jsonify({
+                "message": "Gemini API key is valid",
+                "provider": provider,
+            }), 200
+
+        if provider == "claude":
+            response = requests.get(
+                "https://api.anthropic.com/v1/models",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                },
+                timeout=30,
+            )
+
+            if response.status_code >= 400:
+                return jsonify({
+                    "error": f"Claude API key test failed: {response.text}"
+                }), response.status_code
+
+            return jsonify({
+                "message": "Claude API key is valid",
+                "provider": provider,
+            }), 200
+
+        raise BadRequestError("Unsupported AI provider")
+
+    except (BadRequestError, NotFoundError):
+        raise
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    
+
+@course.route("/test_ai_model", methods=["POST"])
+@cross_origin()
+def test_ai_model():
+    data = request.json
+
+    course_id = data.get("course_id")
+    provider = data.get("provider")
+    model = data.get("model")
+    api_key = data.get("api_key")
+
+    if not provider:
+        raise BadRequestError("Missing provider")
+
+    if not model:
+        raise BadRequestError("Missing model")
+
+    try:
+        if not api_key:
+            if not course_id:
+                raise BadRequestError("Missing course_id or api_key")
+
+            course_obj = db.session.query(Course).filter_by(id=course_id).first()
+
+            if not course_obj:
+                raise NotFoundError("Course not found")
+
+            if provider == "openai" and course_obj.openai_api_key:
+                api_key = decrypt_api_key(course_obj.openai_api_key)
+            elif provider == "gemini" and course_obj.gemini_api_key:
+                api_key = decrypt_api_key(course_obj.gemini_api_key)
+            elif provider == "claude" and course_obj.claude_api_key:
+                api_key = decrypt_api_key(course_obj.claude_api_key)
+            else:
+                raise BadRequestError(f"No saved API key for {provider}")
+
+        test_prompt = (
+            "Return only this JSON object: "
+            "{\"insights\":[\"Model test passed.\"],\"annotations\":[]}"
+        )
+
+        if provider == "openai":
+            client = OpenAI(api_key=api_key)
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Return only valid JSON.",
+                    },
+                    {
+                        "role": "user",
+                        "content": test_prompt,
+                    },
+                ],
+                max_tokens=80,
+                temperature=0,
+                response_format={"type": "json_object"},
+                timeout=30,
+            )
+
+            return jsonify({
+                "message": "OpenAI model is usable",
+                "provider": provider,
+                "model": model,
+                "response": response.choices[0].message.content,
+            }), 200
+
+        if provider == "gemini":
+            response = requests.post(
+                f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+                params={"key": api_key},
+                json={
+                    "contents": [
+                        {
+                            "role": "user",
+                            "parts": [
+                                {
+                                    "text": test_prompt,
+                                }
+                            ],
+                        }
+                    ],
+                    "generationConfig": {
+                        "temperature": 0,
+                        "maxOutputTokens": 80,
+                        "responseMimeType": "application/json",
+                    },
+                },
+                timeout=30,
+            )
+
+            if response.status_code >= 400:
+                return jsonify({
+                    "error": f"Selected Gemini model cannot be used: {response.text}"
+                }), response.status_code
+
+            return jsonify({
+                "message": "Gemini model is usable",
+                "provider": provider,
+                "model": model,
+                "response": response.json(),
+            }), 200
+
+        if provider == "claude":
+            response = requests.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": 80,
+                    "system": "Return only valid JSON.",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": test_prompt,
+                        }
+                    ],
+                },
+                timeout=30,
+            )
+
+            if response.status_code >= 400:
+                return jsonify({
+                    "error": f"Selected Claude model cannot be used: {response.text}"
+                }), response.status_code
+
+            return jsonify({
+                "message": "Claude model is usable",
+                "provider": provider,
+                "model": model,
+                "response": response.json(),
+            }), 200
+
+        raise BadRequestError("Unsupported AI provider")
+
+    except (BadRequestError, NotFoundError):
+        raise
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    
 @course.route("/get_courses_by_instructor", methods=["GET"])
 @cross_origin()
 def get_courses_by_instructor():

--- a/backend/routes/course.py
+++ b/backend/routes/course.py
@@ -17,12 +17,18 @@ from api.models import (
 from api.schemas import AssignmentSchema, CourseSchema, EnrollmentSchema, UserSchema
 from util.errors import BadRequestError, InternalProcessingError, ConflictError, NotFoundError, ForbiddenError
 from util.encryption_utils import encrypt_api_key, decrypt_api_key
+from ai_integration import (
+    CORRECTNESS_SYSTEM_PROMPT,
+    get_gemini_generation_config,
+    parse_feedback_json,
+)
 from openai import OpenAI
 
 course = Blueprint("course", __name__)
 
 ALLOWED_EXTENSIONS = {'csv'}
 UPLOAD_FOLDER = 'uploads'
+SUPPORTED_AI_PROVIDERS = {"openai", "gemini", "claude"}
 
 def is_supported_openai_model(model_id):
     """
@@ -111,21 +117,6 @@ def is_supported_claude_model(model_id):
 
     return model_id.startswith("claude-")
 
-def get_plain_api_key(encrypted_key):
-    """
-    Returns decrypted API key for the frontend password input.
-
-    This allows the UI to keep the saved key hidden by default,
-    while still allowing the user to reveal it with the visibility icon.
-    """
-    if not encrypted_key:
-        return ""
-
-    try:
-        return decrypt_api_key(encrypted_key)
-    except Exception:
-        return ""
-    
 @course.route("/create_course", methods=["POST", "GET"])
 @cross_origin()
 def create_course():
@@ -597,10 +588,6 @@ def get_course_info():
         "has_openai_api_key": bool(course_obj.openai_api_key),
         "has_gemini_api_key": bool(course_obj.gemini_api_key),
         "has_claude_api_key": bool(course_obj.claude_api_key),
-
-        "openai_api_key_value": get_plain_api_key(course_obj.openai_api_key),
-        "gemini_api_key_value": get_plain_api_key(course_obj.gemini_api_key),
-        "claude_api_key_value": get_plain_api_key(course_obj.claude_api_key),
     })
 
     return jsonify([course_data]), 200
@@ -657,6 +644,9 @@ def update_ai_settings():
     if not course_obj:
         raise NotFoundError("Course not found")
 
+    if provider and provider not in SUPPORTED_AI_PROVIDERS:
+        raise BadRequestError("Unsupported AI provider")
+
     if provider:
         course_obj.default_ai_provider = provider
 
@@ -668,9 +658,14 @@ def update_ai_settings():
 
     if temperature is not None:
         try:
-            course_obj.default_ai_temperature = float(temperature)
+            temperature_value = float(temperature)
         except (TypeError, ValueError):
             raise BadRequestError("Invalid temperature")
+
+        if temperature_value < 0 or temperature_value > 1:
+            raise BadRequestError("Temperature must be between 0 and 1")
+
+        course_obj.default_ai_temperature = temperature_value
 
     if api_key:
         if not provider:
@@ -684,8 +679,6 @@ def update_ai_settings():
             course_obj.gemini_api_key = encrypted_api_key
         elif provider == "claude":
             course_obj.claude_api_key = encrypted_api_key
-        else:
-            raise BadRequestError("Unsupported AI provider")
 
     try:
         db.session.commit()
@@ -970,6 +963,14 @@ def test_ai_model():
             "{\"insights\":[\"Model test passed.\"],\"annotations\":[]}"
         )
 
+        def validate_feedback_response(raw_response, provider_name):
+            parsed_feedback, _ = parse_feedback_json(raw_response, provider_name, [])
+
+            if isinstance(parsed_feedback, dict) and parsed_feedback.get("error"):
+                return None
+
+            return parsed_feedback
+
         if provider == "openai":
             client = OpenAI(api_key=api_key)
             response = client.chat.completions.create(
@@ -990,11 +991,19 @@ def test_ai_model():
                 timeout=30,
             )
 
+            raw_response = (response.choices[0].message.content or "").strip()
+            parsed_feedback = validate_feedback_response(raw_response, "OpenAI")
+
+            if parsed_feedback is None:
+                return jsonify({
+                    "error": "Selected OpenAI model did not return valid JSON feedback"
+                }), 400
+
             return jsonify({
                 "message": "OpenAI model is usable",
                 "provider": provider,
                 "model": model,
-                "response": response.choices[0].message.content,
+                "response": parsed_feedback,
             }), 200
 
         if provider == "gemini":
@@ -1007,16 +1016,12 @@ def test_ai_model():
                             "role": "user",
                             "parts": [
                                 {
-                                    "text": test_prompt,
+                                    "text": f"{CORRECTNESS_SYSTEM_PROMPT}\n\n{test_prompt}",
                                 }
                             ],
                         }
                     ],
-                    "generationConfig": {
-                        "temperature": 0,
-                        "maxOutputTokens": 80,
-                        "responseMimeType": "application/json",
-                    },
+                    "generationConfig": get_gemini_generation_config(model, 0),
                 },
                 timeout=30,
             )
@@ -1026,11 +1031,25 @@ def test_ai_model():
                     "error": f"Selected Gemini model cannot be used: {response.text}"
                 }), response.status_code
 
+            data = response.json()
+            candidate = data.get("candidates", [{}])[0]
+            raw_response = "".join(
+                part.get("text", "")
+                for part in candidate.get("content", {}).get("parts", [])
+                if not part.get("thought")
+            )
+            parsed_feedback = validate_feedback_response(raw_response, "Gemini")
+
+            if parsed_feedback is None:
+                return jsonify({
+                    "error": "Selected Gemini model did not return valid JSON feedback"
+                }), 400
+
             return jsonify({
                 "message": "Gemini model is usable",
                 "provider": provider,
                 "model": model,
-                "response": response.json(),
+                "response": parsed_feedback,
             }), 200
 
         if provider == "claude":
@@ -1060,11 +1079,24 @@ def test_ai_model():
                     "error": f"Selected Claude model cannot be used: {response.text}"
                 }), response.status_code
 
+            data = response.json()
+            content = data.get("content", [])
+            raw_response = ""
+            if content and content[0].get("type") == "text":
+                raw_response = content[0].get("text", "")
+
+            parsed_feedback = validate_feedback_response(raw_response, "Claude")
+
+            if parsed_feedback is None:
+                return jsonify({
+                    "error": "Selected Claude model did not return valid JSON feedback"
+                }), 400
+
             return jsonify({
                 "message": "Claude model is usable",
                 "provider": provider,
                 "model": model,
-                "response": response.json(),
+                "response": parsed_feedback,
             }), 200
 
         raise BadRequestError("Unsupported AI provider")

--- a/backend/test/unit/test_ai_integration.py
+++ b/backend/test/unit/test_ai_integration.py
@@ -1,0 +1,147 @@
+from ai_integration import (
+    DEFAULT_FEEDBACK_PROMPT,
+    RETURN_SPEC,
+    build_feedback_prompt,
+    get_structured_feedback_from_gemini,
+    parse_feedback_json,
+)
+
+
+def test_default_feedback_prompt_asks_for_professional_feedback_even_when_tests_pass():
+    assert "Always provide useful feedback" in DEFAULT_FEEDBACK_PROMPT
+    assert "Overall Summary" in DEFAULT_FEEDBACK_PROMPT
+    assert "Correctness Feedback" in DEFAULT_FEEDBACK_PROMPT
+    assert "Improvement Suggestions" in DEFAULT_FEEDBACK_PROMPT
+
+
+def test_return_spec_keeps_insights_for_every_submission():
+    assert "Include general insights for every submission" in RETURN_SPEC
+    assert "annotations only when line-specific feedback is helpful" in RETURN_SPEC
+    assert "Use a single-line code pattern" in RETURN_SPEC
+
+
+def test_build_feedback_prompt_uses_professional_default_prompt():
+    prompt = build_feedback_prompt(
+        base_prompt="",
+        past_insights="No prior insights.",
+        code="print('hello')",
+        autograder_results='{"tests":[]}',
+        style_instruction="Feedback style: balanced.",
+    )
+
+    assert "Always provide useful feedback" in prompt
+    assert "Improvement Suggestions" in prompt
+
+
+def test_parse_feedback_json_accepts_escaped_newlines_inside_code_patterns():
+    raw_response = (
+        '{"insights":["Overall Summary: Feedback is available."],'
+        '"annotations":[{"pattern":"def create_spiral(n):\\n    print(\\"TODO\\")",'
+        '"comment":"Add the missing implementation for this function."}]}'
+    )
+
+    parsed, new_insights = parse_feedback_json(
+        raw_response,
+        "Claude",
+        "No prior insights.",
+    )
+
+    assert "error" not in parsed
+    assert parsed["annotations"][0]["pattern"] == 'def create_spiral(n):\n    print("TODO")'
+    assert new_insights == ["Overall Summary: Feedback is available."]
+
+
+def test_parse_feedback_json_extracts_json_object_from_provider_wrapper_text():
+    raw_response = (
+        "Here is the requested JSON:\n"
+        '{"insights":["Correctness Feedback: Tests failed."],"annotations":[]}\n'
+        "No additional comments."
+    )
+
+    parsed, new_insights = parse_feedback_json(
+        raw_response,
+        "Gemini",
+        "No prior insights.",
+    )
+
+    assert "error" not in parsed
+    assert parsed["insights"] == ["Correctness Feedback: Tests failed."]
+    assert new_insights == ["Correctness Feedback: Tests failed."]
+
+
+def test_parse_feedback_json_escapes_literal_newlines_inside_provider_strings():
+    raw_response = """{
+  "insights": [
+    "Overall Summary: The submission contains significant
+issues that should be fixed."
+  ],
+  "annotations": [
+    {
+      "pattern": "def create_spiral(dim):
+    # ADD YOUR CODE HERE",
+      "comment": "Function body is empty."
+    }
+  ]
+}"""
+
+    parsed, new_insights = parse_feedback_json(
+        raw_response,
+        "Claude",
+        "No prior insights.",
+    )
+
+    assert "error" not in parsed
+    assert parsed["insights"] == [
+        "Overall Summary: The submission contains significant\nissues that should be fixed."
+    ]
+    assert parsed["annotations"][0]["pattern"] == (
+        "def create_spiral(dim):\n    # ADD YOUR CODE HERE"
+    )
+    assert new_insights == parsed["insights"]
+
+
+def test_gemini_feedback_request_reserves_tokens_for_json(monkeypatch):
+    captured_request = {}
+
+    class FakeGeminiResponse:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {
+                                    "text": (
+                                        '{"insights":["Overall Summary: Feedback is ready."],'
+                                        '"annotations":[]}'
+                                    )
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+
+    def fake_post(url, params, json, timeout):
+        captured_request["json"] = json
+        return FakeGeminiResponse()
+
+    monkeypatch.setattr("ai_integration.requests.post", fake_post)
+
+    parsed, new_insights = get_structured_feedback_from_gemini(
+        api_key="gemini-key",
+        prompt="Return JSON feedback.",
+        model="gemini-2.5-flash",
+        temperature=0.5,
+        past_insights=[],
+    )
+
+    generation_config = captured_request["json"]["generationConfig"]
+
+    assert "error" not in parsed
+    assert new_insights == ["Overall Summary: Feedback is ready."]
+    assert generation_config["maxOutputTokens"] >= 1400
+    assert generation_config["thinkingConfig"]["thinkingBudget"] == 0

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -438,9 +438,6 @@ def test_get_course_info_success(client, mocker):
         "name": "CS101",
     }
 
-    mock_get_plain_api_key = mocker.patch("routes.course.get_plain_api_key")
-    mock_get_plain_api_key.side_effect = lambda key: "test-openai-key" if key else ""
-
     response = client.get("/get_course_info", query_string={"course_id": "course-123"})
 
     assert response.status_code == 200
@@ -455,11 +452,12 @@ def test_get_course_info_success(client, mocker):
             "has_openai_api_key": True,
             "has_gemini_api_key": False,
             "has_claude_api_key": False,
-            "openai_api_key_value": "test-openai-key",
-            "gemini_api_key_value": "",
-            "claude_api_key_value": "",
         }
     ]
+
+    assert "openai_api_key_value" not in response.json[0]
+    assert "gemini_api_key_value" not in response.json[0]
+    assert "claude_api_key_value" not in response.json[0]
 
 def test_get_course_info_missing_course_id(client):
     response = client.get("/get_course_info")
@@ -729,6 +727,74 @@ def test_test_ai_model_gemini_success(client, mocker):
     mock_post.assert_called_once()
     assert "gemini-1.5-flash:generateContent" in mock_post.call_args.args[0]
     assert mock_post.call_args.kwargs["params"] == {"key": "test-gemini-key"}
+
+
+def test_test_ai_model_gemini_uses_feedback_generation_config(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": '{"insights":["Model test passed."],"annotations":[]}'
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    mock_post = mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "gemini",
+            "model": "gemini-2.5-flash",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 200
+
+    generation_config = mock_post.call_args.kwargs["json"]["generationConfig"]
+    assert generation_config["maxOutputTokens"] == 1600
+    assert generation_config["responseMimeType"] == "application/json"
+    assert generation_config["thinkingConfig"] == {"thinkingBudget": 0}
+
+
+def test_test_ai_model_gemini_invalid_json_returns_error(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "This model can chat, but did not return JSON."
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "gemini",
+            "model": "gemini-1.5-flash",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "valid JSON feedback" in response.json["error"]
 
 
 def test_test_ai_model_gemini_unavailable_returns_error(client, mocker):
@@ -1253,6 +1319,46 @@ def test_update_ai_settings_invalid_temperature_returns_400(client, mocker):
 
     assert response.status_code == 400
     assert response.json["message"] == "Invalid temperature"
+
+
+def test_update_ai_settings_temperature_out_of_range_returns_400(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+
+    mock_course = mocker.Mock()
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    response = client.put(
+        "/update_ai_settings",
+        json={
+            "course_id": "course-123",
+            "provider": "openai",
+            "temperature": 1.5,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Temperature must be between 0 and 1"
+
+
+def test_update_ai_settings_unsupported_provider_without_api_key_returns_400(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+    mock_commit = mocker.patch("routes.course.db.session.commit")
+
+    mock_course = mocker.Mock()
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    response = client.put(
+        "/update_ai_settings",
+        json={
+            "course_id": "course-123",
+            "provider": "llama",
+            "model_name": "llama-test-model",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Unsupported AI provider"
+    mock_commit.assert_not_called()
 
 
 def test_update_ai_settings_unsupported_provider_for_api_key_returns_400(client, mocker):

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -1063,7 +1063,7 @@ def test_fetch_ai_models_unsupported_provider_returns_400(client):
     assert response.json["message"] == "Unsupported AI provider"
 
 
-def test_fetch_ai_models_openai_filters_chat_models_only(client, mocker):
+def test_fetch_ai_models_openai_filters_unsupported_models(client, mocker):
     mock_gpt_model = mocker.Mock()
     mock_gpt_model.id = "gpt-4o-mini"
 
@@ -1099,7 +1099,7 @@ def test_fetch_ai_models_openai_filters_chat_models_only(client, mocker):
 
     assert response.status_code == 200
     assert "gpt-4o-mini" in response.json["models"]
-    assert "o3-mini" in response.json["models"]
+    assert "o3-mini" not in response.json["models"]
     assert "text-embedding-3-small" not in response.json["models"]
     assert "whisper-1" not in response.json["models"]
 

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -417,15 +417,49 @@ def test_get_course_assignments_missing_course_id(client):
 
 def test_get_course_info_success(client, mocker):
     mock_query = mocker.patch("routes.course.db.session.query")
-    mock_query.return_value.filter_by.return_value = [mocker.Mock(id="course-123", name="CS101")]
+
+    mock_course = mocker.Mock(
+        id="course-123",
+        name="CS101",
+        default_ai_provider="openai",
+        default_ai_model="gpt-4o-mini",
+        default_feedback_style="hint-based",
+        default_ai_temperature=0.5,
+        openai_api_key="encrypted-key",
+        gemini_api_key="",
+        claude_api_key="",
+    )
+
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
     mock_schema = mocker.patch("routes.course.CourseSchema")
-    mock_schema.return_value.dump.return_value = [{"id": "course-123", "name": "CS101"}]
+    mock_schema.return_value.dump.return_value = {
+        "id": "course-123",
+        "name": "CS101",
+    }
+
+    mock_get_plain_api_key = mocker.patch("routes.course.get_plain_api_key")
+    mock_get_plain_api_key.side_effect = lambda key: "test-openai-key" if key else ""
 
     response = client.get("/get_course_info", query_string={"course_id": "course-123"})
 
     assert response.status_code == 200
-    assert response.json == [{"id": "course-123", "name": "CS101"}]
-
+    assert response.json == [
+        {
+            "id": "course-123",
+            "name": "CS101",
+            "default_ai_provider": "openai",
+            "default_ai_model": "gpt-4o-mini",
+            "default_feedback_style": "hint-based",
+            "default_ai_temperature": 0.5,
+            "has_openai_api_key": True,
+            "has_gemini_api_key": False,
+            "has_claude_api_key": False,
+            "openai_api_key_value": "test-openai-key",
+            "gemini_api_key_value": "",
+            "claude_api_key_value": "",
+        }
+    ]
 
 def test_get_course_info_missing_course_id(client):
     response = client.get("/get_course_info")
@@ -532,3 +566,651 @@ def test_enroll_course_db_error(client, mocker):
     response = client.post("/enroll_course", json=payload)
     assert response.status_code == 409
     assert response.json["message"] == "User is already enrolled in this course"
+
+def test_test_ai_api_key_openai_success(client, mocker):
+    mock_openai_class = mocker.patch("routes.course.OpenAI")
+    mock_openai_client = mocker.Mock()
+    mock_openai_client.models.list.return_value = mocker.Mock()
+    mock_openai_class.return_value = mock_openai_client
+
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "provider": "openai",
+            "api_key": "test-openai-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "OpenAI API key is valid"
+    assert response.json["provider"] == "openai"
+
+    mock_openai_class.assert_called_once_with(api_key="test-openai-key")
+    mock_openai_client.models.list.assert_called_once()
+
+
+def test_test_ai_api_key_gemini_success(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"models": []}
+
+    mock_get = mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "provider": "gemini",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Gemini API key is valid"
+    assert response.json["provider"] == "gemini"
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["params"] == {"key": "test-gemini-key"}
+
+
+def test_test_ai_api_key_claude_success(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"data": []}
+
+    mock_get = mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "provider": "claude",
+            "api_key": "test-claude-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Claude API key is valid"
+    assert response.json["provider"] == "claude"
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["headers"]["x-api-key"] == "test-claude-key"
+    assert mock_get.call_args.kwargs["headers"]["anthropic-version"] == "2023-06-01"
+
+
+def test_test_ai_api_key_missing_saved_key_returns_400(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+
+    mock_course = mocker.Mock(
+        id="course-123",
+        openai_api_key="",
+        gemini_api_key="",
+        claude_api_key="",
+    )
+
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "course_id": "course-123",
+            "provider": "gemini",
+        },
+    )
+
+    assert response.status_code == 400
+
+
+def test_test_ai_model_openai_success(client, mocker):
+    mock_message = mocker.Mock()
+    mock_message.content = '{"insights":["Model test passed."],"annotations":[]}'
+
+    mock_choice = mocker.Mock()
+    mock_choice.message = mock_message
+
+    mock_completion = mocker.Mock()
+    mock_completion.choices = [mock_choice]
+
+    mock_openai_client = mocker.Mock()
+    mock_openai_client.chat.completions.create.return_value = mock_completion
+
+    mock_openai_class = mocker.patch(
+        "routes.course.OpenAI",
+        return_value=mock_openai_client,
+    )
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "test-openai-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["provider"] == "openai"
+    assert response.json["model"] == "gpt-4o-mini"
+
+    mock_openai_class.assert_called_once_with(api_key="test-openai-key")
+    mock_openai_client.chat.completions.create.assert_called_once()
+
+
+def test_test_ai_model_gemini_success(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": '{"insights":["Model test passed."],"annotations":[]}'
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    mock_post = mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "gemini",
+            "model": "gemini-1.5-flash",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["provider"] == "gemini"
+    assert response.json["model"] == "gemini-1.5-flash"
+
+    mock_post.assert_called_once()
+    assert "gemini-1.5-flash:generateContent" in mock_post.call_args.args[0]
+    assert mock_post.call_args.kwargs["params"] == {"key": "test-gemini-key"}
+
+
+def test_test_ai_model_gemini_unavailable_returns_error(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 503
+    mock_response.text = (
+        '{"error":{"message":"This model is currently experiencing high demand."}}'
+    )
+
+    mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "gemini",
+            "model": "gemini-2.5-flash",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 503
+    assert "Selected Gemini model cannot be used" in response.json["error"]
+
+
+def test_test_ai_model_claude_success(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "content": [
+            {
+                "type": "text",
+                "text": '{"insights":["Model test passed."],"annotations":[]}',
+            }
+        ]
+    }
+
+    mock_post = mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "claude",
+            "model": "claude-3-5-sonnet-20241022",
+            "api_key": "test-claude-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["provider"] == "claude"
+    assert response.json["model"] == "claude-3-5-sonnet-20241022"
+
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["headers"]["x-api-key"] == "test-claude-key"
+    assert (
+        mock_post.call_args.kwargs["json"]["model"]
+        == "claude-3-5-sonnet-20241022"
+    )
+
+
+def test_test_ai_model_claude_unavailable_returns_error(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 404
+    mock_response.text = (
+        '{"type":"error","error":{"type":"not_found_error",'
+        '"message":"Claude Fable 5 is not available."}}'
+    )
+
+    mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "claude",
+            "model": "claude-fable-5",
+            "api_key": "test-claude-key",
+        },
+    )
+
+    assert response.status_code == 404
+    assert "Selected Claude model cannot be used" in response.json["error"]
+
+
+def test_fetch_ai_models_gemini_filters_and_sorts_models(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "models": [
+            {
+                "name": "models/gemini-2.5-flash",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+            {
+                "name": "models/gemini-1.5-flash",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+            {
+                "name": "models/text-embedding-004",
+                "supportedGenerationMethods": ["embedContent"],
+            },
+        ]
+    }
+
+    mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "gemini",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["models"][0] == "gemini-1.5-flash"
+    assert "gemini-2.5-flash" in response.json["models"]
+    assert "text-embedding-004" not in response.json["models"]
+
+
+def test_fetch_ai_models_claude_filters_unavailable_models(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [
+            {"id": "claude-fable-5"},
+            {"id": "claude-mythos-5"},
+            {"id": "claude-3-5-sonnet-20241022"},
+            {"id": "claude-3-5-haiku-20241022"},
+        ]
+    }
+
+    mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "claude",
+            "api_key": "test-claude-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "claude-fable-5" not in response.json["models"]
+    assert "claude-mythos-5" not in response.json["models"]
+    assert response.json["models"][0] == "claude-3-5-sonnet-20241022"
+
+def test_test_ai_api_key_missing_provider_returns_400(client):
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Missing provider"
+
+
+def test_test_ai_api_key_unsupported_provider_returns_400(client):
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "provider": "llama",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Unsupported AI provider"
+
+
+def test_test_ai_api_key_uses_saved_gemini_key(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+    mock_decrypt = mocker.patch(
+        "routes.course.decrypt_api_key",
+        return_value="decrypted-gemini-key",
+    )
+
+    mock_course = mocker.Mock(
+        id="course-123",
+        openai_api_key="",
+        gemini_api_key="encrypted-gemini-key",
+        claude_api_key="",
+    )
+
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"models": []}
+
+    mock_get = mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "course_id": "course-123",
+            "provider": "gemini",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Gemini API key is valid"
+
+    mock_decrypt.assert_called_once_with("encrypted-gemini-key")
+    assert mock_get.call_args.kwargs["params"] == {"key": "decrypted-gemini-key"}
+
+
+def test_test_ai_api_key_saved_course_not_found_returns_404(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+    mock_query.return_value.filter_by.return_value.first.return_value = None
+
+    response = client.post(
+        "/test_ai_api_key",
+        json={
+            "course_id": "missing-course",
+            "provider": "openai",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json["message"] == "Course not found"
+
+
+def test_test_ai_model_missing_provider_returns_400(client):
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "model": "gpt-4o-mini",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Missing provider"
+
+
+def test_test_ai_model_missing_model_returns_400(client):
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "openai",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Missing model"
+
+
+def test_test_ai_model_unsupported_provider_returns_400(client):
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "provider": "llama",
+            "model": "llama-test-model",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Unsupported AI provider"
+
+
+def test_test_ai_model_uses_saved_claude_key(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+    mock_decrypt = mocker.patch(
+        "routes.course.decrypt_api_key",
+        return_value="decrypted-claude-key",
+    )
+
+    mock_course = mocker.Mock(
+        id="course-123",
+        openai_api_key="",
+        gemini_api_key="",
+        claude_api_key="encrypted-claude-key",
+    )
+
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "content": [
+            {
+                "type": "text",
+                "text": '{"insights":["Model test passed."],"annotations":[]}',
+            }
+        ]
+    }
+
+    mock_post = mocker.patch("routes.course.requests.post", return_value=mock_response)
+
+    response = client.post(
+        "/test_ai_model",
+        json={
+            "course_id": "course-123",
+            "provider": "claude",
+            "model": "claude-3-5-sonnet-20241022",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["provider"] == "claude"
+    assert response.json["model"] == "claude-3-5-sonnet-20241022"
+
+    mock_decrypt.assert_called_once_with("encrypted-claude-key")
+    assert mock_post.call_args.kwargs["headers"]["x-api-key"] == "decrypted-claude-key"
+
+
+def test_fetch_ai_models_missing_provider_returns_400(client):
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Missing provider"
+
+
+def test_fetch_ai_models_unsupported_provider_returns_400(client):
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "llama",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Unsupported AI provider"
+
+
+def test_fetch_ai_models_openai_filters_chat_models_only(client, mocker):
+    mock_gpt_model = mocker.Mock()
+    mock_gpt_model.id = "gpt-4o-mini"
+
+    mock_o_model = mocker.Mock()
+    mock_o_model.id = "o3-mini"
+
+    mock_embedding_model = mocker.Mock()
+    mock_embedding_model.id = "text-embedding-3-small"
+
+    mock_other_model = mocker.Mock()
+    mock_other_model.id = "whisper-1"
+
+    mock_models_response = mocker.Mock()
+    mock_models_response.data = [
+        mock_embedding_model,
+        mock_gpt_model,
+        mock_other_model,
+        mock_o_model,
+    ]
+
+    mock_openai_client = mocker.Mock()
+    mock_openai_client.models.list.return_value = mock_models_response
+
+    mocker.patch("routes.course.OpenAI", return_value=mock_openai_client)
+
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "openai",
+            "api_key": "test-openai-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "gpt-4o-mini" in response.json["models"]
+    assert "o3-mini" in response.json["models"]
+    assert "text-embedding-3-small" not in response.json["models"]
+    assert "whisper-1" not in response.json["models"]
+
+
+def test_fetch_ai_models_gemini_api_error_returns_provider_error(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 403
+    mock_response.text = '{"error":{"message":"API key not valid."}}'
+
+    mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "gemini",
+            "api_key": "bad-gemini-key",
+        },
+    )
+
+    assert response.status_code == 403
+    assert "API key not valid" in response.json["error"]
+
+
+def test_fetch_ai_models_claude_api_error_returns_provider_error(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 401
+    mock_response.text = '{"type":"error","error":{"message":"invalid x-api-key"}}'
+
+    mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "claude",
+            "api_key": "bad-claude-key",
+        },
+    )
+
+    assert response.status_code == 401
+    assert "invalid x-api-key" in response.json["error"]
+
+
+def test_update_ai_settings_updates_openai_key_and_defaults(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+    mock_encrypt = mocker.patch(
+        "routes.course.encrypt_api_key",
+        return_value="encrypted-openai-key",
+    )
+    mock_commit = mocker.patch("routes.course.db.session.commit")
+
+    mock_course = mocker.Mock()
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    response = client.put(
+        "/update_ai_settings",
+        json={
+            "course_id": "course-123",
+            "provider": "openai",
+            "model_name": "gpt-4o-mini",
+            "api_key": "plain-openai-key",
+            "feedback_style": "balanced",
+            "temperature": 0.3,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "AI settings updated successfully"
+
+    assert mock_course.default_ai_provider == "openai"
+    assert mock_course.default_ai_model == "gpt-4o-mini"
+    assert mock_course.default_feedback_style == "balanced"
+    assert mock_course.default_ai_temperature == 0.3
+    assert mock_course.openai_api_key == "encrypted-openai-key"
+
+    mock_encrypt.assert_called_once_with("plain-openai-key")
+    mock_commit.assert_called_once()
+
+
+def test_update_ai_settings_invalid_temperature_returns_400(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+
+    mock_course = mocker.Mock()
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    response = client.put(
+        "/update_ai_settings",
+        json={
+            "course_id": "course-123",
+            "provider": "openai",
+            "temperature": "hot",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Invalid temperature"
+
+
+def test_update_ai_settings_unsupported_provider_for_api_key_returns_400(client, mocker):
+    mock_query = mocker.patch("routes.course.db.session.query")
+
+    mock_course = mocker.Mock()
+    mock_query.return_value.filter_by.return_value.first.return_value = mock_course
+
+    response = client.put(
+        "/update_ai_settings",
+        json={
+            "course_id": "course-123",
+            "provider": "llama",
+            "api_key": "plain-key",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json["message"] == "Unsupported AI provider"

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -1067,6 +1067,18 @@ def test_fetch_ai_models_openai_filters_unsupported_models(client, mocker):
     mock_gpt_model = mocker.Mock()
     mock_gpt_model.id = "gpt-4o-mini"
 
+    mock_audio_model = mocker.Mock()
+    mock_audio_model.id = "gpt-4o-audio-preview"
+
+    mock_realtime_model = mocker.Mock()
+    mock_realtime_model.id = "gpt-4o-realtime-preview"
+
+    mock_search_model = mocker.Mock()
+    mock_search_model.id = "gpt-4o-mini-search-preview"
+
+    mock_o_model_full = mocker.Mock()
+    mock_o_model_full.id = "o3"
+
     mock_o_model = mocker.Mock()
     mock_o_model.id = "o3-mini"
 
@@ -1080,7 +1092,11 @@ def test_fetch_ai_models_openai_filters_unsupported_models(client, mocker):
     mock_models_response.data = [
         mock_embedding_model,
         mock_gpt_model,
+        mock_audio_model,
+        mock_realtime_model,
+        mock_search_model,
         mock_other_model,
+        mock_o_model_full,
         mock_o_model,
     ]
 
@@ -1099,9 +1115,51 @@ def test_fetch_ai_models_openai_filters_unsupported_models(client, mocker):
 
     assert response.status_code == 200
     assert "gpt-4o-mini" in response.json["models"]
+    assert "gpt-4o-audio-preview" not in response.json["models"]
+    assert "gpt-4o-realtime-preview" not in response.json["models"]
+    assert "gpt-4o-mini-search-preview" not in response.json["models"]
+    assert "o3" not in response.json["models"]
     assert "o3-mini" not in response.json["models"]
     assert "text-embedding-3-small" not in response.json["models"]
     assert "whisper-1" not in response.json["models"]
+
+
+def test_fetch_ai_models_gemini_filters_preview_and_experimental_models(client, mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "models": [
+            {
+                "name": "models/gemini-2.5-flash",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+            {
+                "name": "models/gemini-2.5-pro-preview-06-05",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+            {
+                "name": "models/gemini-2.0-flash-exp",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+            {
+                "name": "models/gemini-2.5-flash-preview-tts",
+                "supportedGenerationMethods": ["generateContent"],
+            },
+        ]
+    }
+
+    mocker.patch("routes.course.requests.get", return_value=mock_response)
+
+    response = client.post(
+        "/fetch_ai_models",
+        json={
+            "provider": "gemini",
+            "api_key": "test-gemini-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["models"] == ["gemini-2.5-flash"]
 
 
 def test_fetch_ai_models_gemini_api_error_returns_provider_error(client, mocker):

--- a/docs/AI_Settings_Guide.md
+++ b/docs/AI_Settings_Guide.md
@@ -1,0 +1,424 @@
+# AI Settings Guide
+
+## Purpose
+
+AI Settings lets instructors configure AI feedback for programming assignments.
+
+Supported providers:
+
+* OpenAI / ChatGPT
+* Google Gemini
+* Anthropic Claude
+
+AI feedback should focus on **correctness and debugging**, not style, formatting, readability, or refactoring.
+
+---
+
+## Key Files
+
+### Frontend
+
+```text
+frontend/src/pages/instructor/aiSettings/index.js
+frontend/src/pages/instructor/assignments/CreateAssignment.js
+frontend/src/pages/assignmentSettings/index.js
+frontend/src/services/course.js
+```
+
+### Backend
+
+```text
+backend/routes/course.py
+backend/ai_integration.py
+backend/api/models.py
+backend/test/unit/test_course.py
+```
+
+---
+
+## Course-Level AI Settings
+
+Course-level settings are the default AI settings for a course.
+
+Instructors can configure:
+
+* Provider
+* API key
+* Default model
+* Feedback style
+* Temperature
+
+Saved course fields:
+
+```python
+default_ai_provider
+default_ai_model
+openai_api_key
+gemini_api_key
+claude_api_key
+default_feedback_style
+default_ai_temperature
+```
+
+---
+
+## Assignment-Level AI Settings
+
+Each assignment can either:
+
+1. Use course default AI settings.
+2. Customize provider/model for that assignment only.
+
+Assignment fields:
+
+```python
+ai_feedback_enabled
+use_course_ai_default
+ai_feedback_provider
+ai_feedback_model
+ai_feedback_prompt
+ai_feedback_temperature
+ai_feedback_style
+```
+
+Recommended default:
+
+```text
+Use course default
+```
+
+---
+
+## API Key Test vs Model Test
+
+There are two separate tests because a valid API key does not guarantee the selected model works.
+
+### Test API Key
+
+Endpoint:
+
+```text
+POST /test_ai_api_key
+```
+
+Checks whether the provider API key is valid.
+
+### Test Selected Model
+
+Endpoint:
+
+```text
+POST /test_ai_model
+```
+
+Checks whether the selected provider/model can generate a response.
+
+### Result Meaning
+
+```text
+API Key failed:
+  Provider/key problem.
+
+API Key passed, Model failed:
+  Key is valid, but selected model is unavailable or unsupported.
+
+Both passed:
+  Provider/model is ready to use.
+```
+
+---
+
+## Fetch Models
+
+Endpoint:
+
+```text
+POST /fetch_ai_models
+```
+
+Use this before selecting a model.
+
+Frontend note:
+
+```text
+Click Fetch Models first to load all available models.
+Before fetching, the dropdown may only show the saved/default model.
+```
+
+Both pages use this backend route:
+
+```text
+Course AI Settings model dropdown
+Create Assignment custom model dropdown
+```
+
+So model filtering should happen in the backend.
+
+---
+
+## Model Filtering Rules
+
+Some provider APIs return models that appear available but cannot be used for this feedback workflow.
+
+Filtering should be handled in:
+
+```text
+backend/routes/course.py
+```
+
+### OpenAI
+
+Recommended:
+
+```text
+gpt-4o-mini
+gpt-4o
+gpt-4.1-mini
+gpt-4.1
+```
+
+Avoid for now:
+
+```text
+o3-mini
+o4-mini
+```
+
+Reason:
+
+```text
+They may reject max_tokens and require max_completion_tokens.
+```
+
+### Gemini
+
+Recommended:
+
+```text
+gemini-1.5-flash
+gemini-1.5-pro
+gemini-2.5-flash
+gemini-2.5-pro
+```
+
+Avoid:
+
+```text
+gemini-2.0-flash
+deep-research models
+antigravity models
+embedding models
+audio/image/video models
+```
+
+Reason:
+
+```text
+They may not support the standard generateContent feedback request.
+```
+
+### Claude
+
+Recommended:
+
+```text
+claude-3-5-sonnet-20241022
+claude-3-5-haiku-20241022
+claude-3-opus-20240229
+```
+
+Avoid:
+
+```text
+claude-fable
+claude-mythos
+```
+
+Also note:
+
+```text
+Some Claude models reject temperature in the request body.
+Remove temperature from the Claude model test request.
+```
+
+---
+
+## Prompt Behavior
+
+If the assignment prompt is blank:
+
+```text
+Backend uses the built-in default prompt.
+```
+
+If the assignment prompt has text:
+
+```text
+Custom prompt replaces the default prompt.
+```
+
+It does **not** append to the default prompt.
+
+The prompt should focus on:
+
+* Incorrect logic
+* Missing required behavior
+* Failed tests
+* Edge cases
+* Runtime errors
+* Incorrect input/output
+* Incorrect return values
+* Algorithm mistakes
+
+The prompt should avoid:
+
+* Style
+* Formatting
+* Naming
+* Indentation
+* Readability
+* Refactoring
+
+---
+
+## Basic Testing
+
+### Backend
+
+From `backend`:
+
+```bash
+PYTHONPATH=. python -m pytest
+```
+
+### Frontend
+
+From `frontend`:
+
+```bash
+npm test -- --watchAll=false
+```
+
+### Manual Check
+
+Confirm:
+
+```text
+[ ] API key test works.
+[ ] Selected model test works.
+[ ] Fetch Models removes bad models.
+[ ] Course default settings save and reload.
+[ ] Assignment can use course default AI settings.
+[ ] Assignment can use custom AI settings.
+[ ] AI feedback appears or shows a clear error.
+```
+
+---
+
+## Database Cleanup for Old Bad Models
+
+Old saved models may still appear even after backend filtering.
+
+Enter Postgres:
+
+```bash
+docker exec -it postgres_container psql -U postgres -d codeassist
+```
+
+Clean course defaults:
+
+```sql
+UPDATE courses
+SET default_ai_model = 'gpt-4o-mini'
+WHERE default_ai_provider = 'openai'
+  AND default_ai_model IN ('o3-mini', 'o4-mini');
+
+UPDATE courses
+SET default_ai_model = 'gemini-1.5-flash'
+WHERE default_ai_provider = 'gemini'
+  AND (
+    default_ai_model = 'gemini-2.0-flash'
+    OR default_ai_model ILIKE '%deep-research%'
+    OR default_ai_model ILIKE '%antigravity%'
+  );
+```
+
+Clean assignment custom models:
+
+```sql
+UPDATE assignments
+SET ai_feedback_model = NULL
+WHERE ai_feedback_provider = 'openai'
+  AND ai_feedback_model IN ('o3-mini', 'o4-mini');
+
+UPDATE assignments
+SET ai_feedback_model = NULL
+WHERE ai_feedback_provider = 'gemini'
+  AND (
+    ai_feedback_model = 'gemini-2.0-flash'
+    OR ai_feedback_model ILIKE '%deep-research%'
+    OR ai_feedback_model ILIKE '%antigravity%'
+  );
+```
+
+Exit:
+
+```sql
+\q
+```
+
+---
+
+## Common Issues
+
+### API key works, model fails
+
+Meaning:
+
+```text
+The key is valid, but the selected model is unsupported or unavailable.
+```
+
+Fix:
+
+```text
+Fetch models again and choose another model.
+```
+
+### Bad model still appears
+
+Meaning:
+
+```text
+The bad model is already saved in the database.
+```
+
+Fix:
+
+```text
+Clean courses or assignments table.
+```
+
+### OpenAI max_tokens error
+
+Fix:
+
+```text
+Filter out o3-mini and o4-mini, or update backend to use max_completion_tokens.
+```
+
+### Gemini generateContent or JSON error
+
+Fix:
+
+```text
+Filter out special models like deep-research, antigravity, embedding, audio, image, and video models.
+```
+
+### Claude temperature error
+
+Fix:
+
+```text
+Remove temperature from Claude test request body.
+```

--- a/frontend/src/constants/aiFeedback.js
+++ b/frontend/src/constants/aiFeedback.js
@@ -1,0 +1,56 @@
+export const DEFAULT_AI_FEEDBACK_PROMPT = `You are giving short, student-facing feedback on a programming assignment.
+
+Your goal is to help the student understand their submission quality, correctness, and possible improvements without revealing the full solution.
+
+Always provide useful feedback, even if the submitted code passes all visible tests.
+
+Feedback should be professional, concise, and similar to feedback from a programming course autograder or Gradescope-style review.
+
+Required feedback sections:
+1. Overall Summary
+   - Briefly summarize whether the submission appears correct based on the test results and available code.
+   - If all tests pass, mention that no major correctness issue is obvious.
+
+2. Correctness Feedback
+   - Comment on failed tests, missing behavior, runtime errors, incorrect outputs, or edge cases.
+   - If there are no failed tests, say that the implementation appears to satisfy the tested requirements.
+
+3. Improvement Suggestions
+   - Give safe suggestions about robustness, edge cases, maintainability, or clarity.
+   - Suggestions should help the student improve without rewriting their code.
+
+4. Line Comments
+   - Add line-level comments only when a specific line or small code section is worth noting.
+   - Line comments can point out possible bugs, fragile logic, edge case risks, or useful improvements.
+   - Use a single-line code pattern for each annotation. Do not include newline characters in the pattern value.
+   - Do not force line comments if there is no meaningful line-specific feedback.
+
+Allowed feedback topics:
+- Incorrect logic
+- Missing required behavior
+- Failed test cases
+- Edge cases
+- Runtime errors
+- Incorrect input/output handling
+- Incorrect return values
+- Algorithm mistakes
+- Robustness concerns
+- Maintainability concerns that could affect future correctness
+- Clear improvement suggestions
+
+Avoid:
+- Nitpicky formatting feedback
+- Pure style-only comments
+- Personal criticism
+- Rewriting the student's solution
+- Giving copy-paste fixes
+- Revealing the full answer
+
+Rules:
+- Keep the tone professional and encouraging.
+- Do not provide corrected code.
+- Do not give copy-paste fixes.
+- Do not reveal the final answer.
+- Keep each comment short and specific.
+- If all tests pass, still provide an overall summary and at least one improvement or robustness suggestion when possible.
+- If no meaningful improvement is visible, say the submission appears solid based on the available tests.`;

--- a/frontend/src/pages/assignmentSettings/index.js
+++ b/frontend/src/pages/assignmentSettings/index.js
@@ -1,117 +1,204 @@
 import { DeleteOutlined } from "@ant-design/icons";
-import { 
-  Button, 
-  Card, 
-  Checkbox, 
-  Col, 
-  DatePicker, 
-  Form, 
-  Input, 
-  message, 
-  PageHeader, 
-  Radio, 
-  Row, 
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Col,
+  DatePicker,
+  Form,
+  Input,
+  message,
+  PageHeader,
+  Radio,
+  Row,
   Space,
-  Popconfirm
+  Popconfirm,
+  Select,
 } from "antd";
 import { useCallback, useEffect, useState } from "react";
 import { useContext } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { GlobalContext } from "../../App";
-import { deleteAssignment, deleteSubmissions, getAssignment, updateAssignment } from "../../services/assignment";
+import {
+  deleteAssignment,
+  deleteSubmissions,
+  getAssignment,
+  updateAssignment,
+} from "../../services/assignment";
+import { getCourseInfo, fetchAiModels } from "../../services/course";
 import moment from "moment";
 
 export default () => {
   const { assignmentId } = useParams();
   const [form] = Form.useForm();
+
   const [courseId, setCourseId] = useState("");
   const [publishedBefore, setPubBefore] = useState(undefined);
   const [originalPublish, setOGPub] = useState(undefined);
   const [enableAiFeedback, setEnableAiFeedback] = useState(false);
-  const { assignmentInfo, updateAssignmentInfo } = useContext(GlobalContext);
 
+  const [courseAiInfo, setCourseAiInfo] = useState({});
+  const [assignmentModels, setAssignmentModels] = useState([]);
+  const [assignmentModelsLoading, setAssignmentModelsLoading] = useState(false);
+
+  const { updateAssignmentInfo } = useContext(GlobalContext);
+  const navigate = useNavigate();
+
+  const useCourseAiDefault = Form.useWatch("use_course_ai_default", form);
+
+  const loadCourseAiInfo = useCallback(
+    async (targetCourseId) => {
+      if (!targetCourseId) {
+        return;
+      }
+
+      try {
+        const res = await getCourseInfo({ course_id: targetCourseId });
+        const course = res?.data?.[0] || {};
+        setCourseAiInfo(course);
+      } catch (e) {
+        console.error("Failed to load course AI settings:", e);
+      }
+    },
+    []
+  );
 
   const getAssignmentInfo = useCallback(() => {
-    getAssignment({ assignment_id: assignmentId }).then(res => {
-      const { name, published, due_date, autograder_points, course_id, published_date, 
-        ai_feedback_enabled, ai_feedback_prompt, ai_feedback_model, ai_feedback_temperature } = res.data || {};      
-        setPubBefore(published);
+    getAssignment({ assignment_id: assignmentId }).then((res) => {
+      const {
+        name,
+        published,
+        due_date,
+        autograder_points,
+        course_id,
+        published_date,
+        ai_feedback_enabled,
+        use_course_ai_default,
+        ai_feedback_provider,
+        ai_feedback_prompt,
+        ai_feedback_model,
+        ai_feedback_temperature,
+        ai_feedback_style,
+      } = res.data || {};
 
+      setPubBefore(published);
       setOGPub(published_date);
-      setCourseId(course_id)
+      setCourseId(course_id);
+      setEnableAiFeedback(!!ai_feedback_enabled);
+
+      loadCourseAiInfo(course_id);
+
       form.setFieldsValue({
         name,
         published,
         autograderPoints: autograder_points,
-        dueDate: moment.utc(due_date).local(),
-        releaseDate: moment.utc(published_date).local(),
-        enableAiFeedback: ai_feedback_enabled,
-        ai_feedback_prompt,
-        ai_feedback_model,
-        ai_feedback_temperature
-      });
+        dueDate: due_date ? moment.utc(due_date).local() : null,
+        releaseDate: published_date ? moment.utc(published_date).local() : null,
 
-      setEnableAiFeedback(ai_feedback_enabled);
+        enableAiFeedback: !!ai_feedback_enabled,
+        use_course_ai_default: use_course_ai_default !== false,
+        ai_feedback_provider: ai_feedback_provider || "openai",
+        ai_feedback_prompt: ai_feedback_prompt || "",
+        ai_feedback_model: ai_feedback_model || undefined,
+        ai_feedback_temperature: ai_feedback_temperature ?? 0.5,
+        ai_feedback_style: ai_feedback_style || "balanced",
+      });
     });
-  }, [assignmentId, form]);
+  }, [assignmentId, form, loadCourseAiInfo]);
 
   useEffect(() => {
     getAssignmentInfo();
   }, [getAssignmentInfo]);
 
-  const handleDeleteAssignment = async (assignmentId) => {
-  if (!assignmentId) {
-    message.error('Assignment ID is undefined');
-    return;
-  }
-  try {
-    await deleteAssignment(assignmentId);
-    message.success("Assignment deleted successfully");
-  } catch (error) {
-    console.error("Failed to delete assignment:", error);
-    message.error("Failed to delete assignment");
-  }
-};
+  const handleFetchAssignmentModels = async () => {
+    const provider = form.getFieldValue("ai_feedback_provider") || "openai";
 
-const handleDeleteSubmissions = async (assignmentId) => {
-  if (!assignmentId) {
-    message.error('Assignment ID is undefined');
-    return;
-  }
-  try {
-    await deleteSubmissions(assignmentId);
-    message.success("All submissions deleted successfully");
-  } catch (error) {
-    console.error("Failed to delete submissions:", error);
-    message.error("Failed to delete submissions");
-  }
-};
+    try {
+      setAssignmentModelsLoading(true);
+
+      const response = await fetchAiModels({
+        course_id: courseId,
+        provider,
+      });
+
+      const fetchedModels = response?.data?.models || [];
+      setAssignmentModels(fetchedModels);
+
+      if (fetchedModels.length > 0) {
+        const preferredModel = fetchedModels.includes(courseAiInfo.default_ai_model)
+          ? courseAiInfo.default_ai_model
+          : fetchedModels[0];
+
+        form.setFieldsValue({
+          ai_feedback_model: preferredModel,
+        });
+      }
+
+      message.success("Models fetched successfully");
+    } catch (e) {
+      console.error("Failed to fetch models:", e.response?.data || e);
+      message.error(e.response?.data?.error || "Failed to fetch models");
+    } finally {
+      setAssignmentModelsLoading(false);
+    }
+  };
+
+  const handleDeleteAssignment = async (currentAssignmentId) => {
+    if (!currentAssignmentId) {
+      message.error("Assignment ID is undefined");
+      return;
+    }
+
+    try {
+      await deleteAssignment(currentAssignmentId);
+      message.success("Assignment deleted successfully");
+    } catch (error) {
+      console.error("Failed to delete assignment:", error);
+      message.error("Failed to delete assignment");
+    }
+  };
+
+  const handleDeleteSubmissions = async (currentAssignmentId) => {
+    if (!currentAssignmentId) {
+      message.error("Assignment ID is undefined");
+      return;
+    }
+
+    try {
+      await deleteSubmissions(currentAssignmentId);
+      message.success("All submissions deleted successfully");
+    } catch (error) {
+      console.error("Failed to delete submissions:", error);
+      message.error("Failed to delete submissions");
+    }
+  };
 
   const currentDate = () => {
     const current = new Date();
-    const formatDate = current.toISOString();
-    return formatDate
-  }
+    return current.toISOString();
+  };
 
   const finishForm = async () => {
-      if (!assignmentId) {
+    if (!assignmentId) {
       message.error("Assignment ID is missing. Cannot update.");
       return;
     }
 
     const values = form.getFieldsValue();
+
     let publishedDate = undefined;
     if (values.published === true) {
-      publishedDate = (publishedBefore && originalPublish) ? originalPublish : currentDate();
+      publishedDate = publishedBefore && originalPublish ? originalPublish : currentDate();
     } else {
-      publishedDate = values.releaseDate._d;
+      publishedDate = values.releaseDate?._d || values.releaseDate;
     }
 
     const newAssignmentData = {
       assignment_id: assignmentId,
       name: values.name,
       course_id: courseId,
-      due_date: values.dueDate._d,
+      due_date: values.dueDate?._d || values.dueDate,
       autograder_points: values.autograderPoints,
       anonymous_grading: values.submissionAnonymization,
       manual_grading: values.manualGrading,
@@ -123,59 +210,67 @@ const handleDeleteSubmissions = async (assignmentId) => {
       published: values.published,
       published_date: publishedDate,
 
-      // AI Feedback Config
-      ai_feedback_enabled: values.enableAiFeedback,
-      ai_feedback_prompt: values.ai_feedback_prompt,
-      ai_feedback_model: values.ai_feedback_model,
-      ai_feedback_temperature: values.ai_feedback_temperature
+      ai_feedback_enabled: !!values.enableAiFeedback,
+      use_course_ai_default: values.use_course_ai_default !== false,
+      ai_feedback_provider:
+        values.use_course_ai_default === false ? values.ai_feedback_provider : null,
+      ai_feedback_model:
+        values.use_course_ai_default === false ? values.ai_feedback_model : null,
+      ai_feedback_prompt: values.ai_feedback_prompt ?? null,
+      ai_feedback_temperature: values.ai_feedback_temperature ?? null,
+      ai_feedback_style: values.ai_feedback_style ?? null,
     };
+
     const validData = Object.fromEntries(
       Object.entries(newAssignmentData).filter(([_, value]) => value !== undefined)
     );
+
     try {
-    await updateAssignment(validData);
-    message.success("Successfully updated assignment");
+      await updateAssignment(validData);
+      message.success("Successfully updated assignment");
 
-    const res = await getAssignment({ assignment_id: assignmentId });
-    updateAssignmentInfo(res.data);
+      const res = await getAssignment({ assignment_id: assignmentId });
+      updateAssignmentInfo(res.data);
+    } catch (err) {
+      message.error("Failed to update assignment. Please try again.");
+      console.error("Update error:", err);
+    }
+  };
 
-  } catch (err) {
-    message.error("Failed to update assignment. Please try again.");
-    console.error("Update error:", err);
-  }
-};
-
-  const navigate = useNavigate();
   const navigateMainPage = () => {
-    navigate(`/instructorDashboard/${courseId}`)
-  }
+    navigate(`/instructorDashboard/${courseId}`);
+  };
 
   return (
     <>
-      <PageHeader title='Edit Programming Assignment' />
+      <PageHeader title="Edit Programming Assignment" />
+
       <Form
-        layout='vertical'
+        layout="vertical"
         form={form}
-        onFinish={() => {
-          finishForm();
+        onFinish={async () => {
+          await finishForm();
           navigateMainPage();
         }}
       >
-        <Card >
-          {/* <Form.Item label='TITLE'> */}
-          <Form.Item 
-            label={<span>NAME</span>} 
-            name='name' 
-            rules={[{ required: true, message: 'Please enter a title' }]}>
+        <Card>
+          <Form.Item
+            label={<span>NAME</span>}
+            name="name"
+            rules={[{ required: true, message: "Please enter a title" }]}
+          >
             <Input />
           </Form.Item>
-          <Form.Item 
-            label='AUTOGRADER POINTS' 
-            name='autograderPoints' 
-            rules={[{ required: true, message: 'Please enter points' }]}>
+
+          <Form.Item
+            label="AUTOGRADER POINTS"
+            name="autograderPoints"
+            rules={[{ required: true, message: "Please enter points" }]}
+          >
             <Input />
           </Form.Item>
-          <Form.Item label='PUBLISHED' name='published'>
+
+          <Form.Item label="PUBLISHED" name="published">
             <Radio.Group
               options={[
                 { label: "YES", value: true },
@@ -183,196 +278,220 @@ const handleDeleteSubmissions = async (assignmentId) => {
               ]}
             />
           </Form.Item>
-          {/* NEED TO CONNECT TO BACKEND  */}
-          {/* <Form.Item label='SUBMISSION ANONYMIZATION'>
-            <Checkbox>Enable Anonymous Grading</Checkbox>
-            <div style={{ marginLeft: "24px", color: "grey" }}>
-              Hide identifiable student information from being listed with
-              submissions.
-            </div>
-          </Form.Item> */} 
-          {/* <Form.Item label='CANVAS ASSIGNMENT'>
-            <Space>
-              <Input style={{ width: "205px" }} />
-              <Button>Change</Button>
-              <Button danger type='primary'>
-                Unlink
-              </Button>
-            </Space>
-          </Form.Item> */}
+
           <Form.Item>
             <Row gutter={20}>
               <Col>
                 <Form.Item
-                  label='RELEASE DATE (CST)'
-                  name='releaseDate'
-                  rules={[{ required: true, message: 'Please select a release date' }]}
+                  label="RELEASE DATE (CST)"
+                  name="releaseDate"
+                  rules={[
+                    { required: true, message: "Please select a release date" },
+                  ]}
                 >
                   <DatePicker showTime style={{ width: "100%" }} />
                 </Form.Item>
-                <Form.Item>
+
+                <Form.Item name="allowLateSubmissions" valuePropName="checked">
                   <Checkbox>Allow Late Submissions</Checkbox>
                 </Form.Item>
               </Col>
+
               <Col>
                 <Form.Item
-                  label='DUE DATE (CST)'
-                  name='dueDate'
-                  rules={[{ required: true, message: 'Please select a due date' }]}
+                  label="DUE DATE (CST)"
+                  name="dueDate"
+                  rules={[{ required: true, message: "Please select a due date" }]}
                 >
                   <DatePicker showTime style={{ width: "100%" }} />
                 </Form.Item>
-                <Form.Item label='LATE DUE DATE (CST)' name='lateDueDate'>
+
+                <Form.Item label="LATE DUE DATE (CST)" name="lateDueDate">
                   <DatePicker showTime style={{ width: "100%" }} />
                 </Form.Item>
               </Col>
             </Row>
           </Form.Item>
-          {/* <Form.Item label='GROUP SUBMISSION'>
-            <Checkbox>Enable Group Submission</Checkbox>
-          </Form.Item>
-          <Form.Item label='LIMIT GROUP SIZE'>
-            <Input placeholder='No Max' />
-          </Form.Item>
-          <Form.Item label='MANUAL GRADING'>
-            <Checkbox>Enable Manual Grading</Checkbox>
-          </Form.Item>
-          <Form.Item label='LEADERBOARD'>
-            <Checkbox>Enable Leaderboard</Checkbox>
-          </Form.Item>
-          <Form.Item label='DEFAULT NUMBER OF ENTRIES SHOWN' name="leaderBoard">
-            <Input placeholder='No Max' />
-          </Form.Item>
-          <Form.Item label='SUBMISSION METHODS ENABLED'>
-            <Space direction='vertical'>
-              <Checkbox>Upload</Checkbox>
-              <Checkbox>GitHub</Checkbox>
-              <Checkbox>Bitbucket</Checkbox>
-            </Space>
-          </Form.Item>
-          <Form.Item label='IGNORED FILES'>
-            <Input.TextArea />
-            <span style={{ color: "grey" }}>Follows gitignore format.</span>
-          </Form.Item> */}
-          {/* <Form.Item
-            label={
-              <Space direction='vertical'>
-                <div>CONTAINER SPECIFICATIONS</div>
-                <div style={{ color: "grey" }}>
-                  Your autograder will have access to at least the portion of
-                  CPU allocated, and at most the memory allocated.
-                </div>
-              </Space>
-            }
-          >
-            <Space direction='vertical'>
-              <Checkbox>0.5 CPU, 0.75GB RAM</Checkbox>
-              <Checkbox>1.0 CPU, 1.5GB RAM</Checkbox>
-              <Checkbox>2.0 CPU, 3.0GB RAM</Checkbox>
-              <Checkbox>4.0 CPU, 6.0GB RAM</Checkbox>
-            </Space>
-          </Form.Item>
-          <Form.Item
-            label={
-              <Space direction='vertical'>
-                <div>AUTOGRADER TIMEOUT</div>
-                <div style={{ color: "grey" }}>
-                  Your autograder will be timed out after this amount of time.
-                </div>
-              </Space>
-            }
-          >
-            <Select
-              options={[
-                { label: "10 minutes", value: "10" },
-                { label: "20 minutes", value: "20" },
-              ]}
-            />
-          </Form.Item> */}
 
-        {/* AI Settings */}
-        <Form.Item label="ENABLE AI FEEDBACK" name="enableAiFeedback" valuePropName="checked">
-          <Checkbox onChange={(e) => setEnableAiFeedback(e.target.checked)}>
-            Enable AI Feedback
-          </Checkbox>
-        </Form.Item>
+          <Card title="AI Feedback Settings" style={{ marginBottom: 24 }}>
+            <Form.Item
+              label="Enable AI Feedback"
+              name="enableAiFeedback"
+              valuePropName="checked"
+            >
+              <Checkbox onChange={(e) => setEnableAiFeedback(e.target.checked)}>
+                Enable AI Feedback
+              </Checkbox>
+            </Form.Item>
 
-        <Form.Item
-          label="AI FEEDBACK PROMPT"
-          name="ai_feedback_prompt"
-          rules={[{ required: enableAiFeedback, message: "Please enter a feedback prompt" }]}
-        >
-          <Input.TextArea
-            placeholder="Enter the feedback prompt for AI"
-            autoSize={{ minRows: 4, maxRows: 8 }}
-            disabled={!enableAiFeedback}
-          />
-        </Form.Item>
+            {enableAiFeedback && (
+              <>
+                <Alert
+                  type={
+                    courseAiInfo.has_openai_api_key ||
+                    courseAiInfo.has_gemini_api_key ||
+                    courseAiInfo.has_claude_api_key
+                      ? "success"
+                      : "warning"
+                  }
+                  showIcon
+                  style={{ marginBottom: 16 }}
+                  message="Current Course AI Default"
+                  description={
+                    courseAiInfo.default_ai_provider && courseAiInfo.default_ai_model
+                      ? `Using ${courseAiInfo.default_ai_provider} / ${courseAiInfo.default_ai_model} by default.`
+                      : "Course default AI settings are incomplete. Configure them in Course AI Settings first."
+                  }
+                />
 
-        <Form.Item
-          label="AI MODEL USED"
-          name="ai_feedback_model"
-          rules={[{ required: enableAiFeedback, message: "Please select an AI model (e.g. gpt-5o)" }]}
-        >
-          <Input.TextArea
-            placeholder="gpt-5o"
-            autoSize={{ minRows: 1, maxRows: 1}}
-            disabled={!enableAiFeedback}
-          />
-        </Form.Item>
+                <Form.Item
+                  label="Model Source"
+                  name="use_course_ai_default"
+                  initialValue={true}
+                >
+                  <Radio.Group>
+                    <Space direction="vertical">
+                      <Radio value={true}>
+                        Use course default
+                        <span style={{ color: "#888", marginLeft: 8 }}>
+                          {courseAiInfo.default_ai_provider || "No provider"} /{" "}
+                          {courseAiInfo.default_ai_model || "No model"}
+                        </span>
+                      </Radio>
 
-        {/* <Form.Item
-          label="AI MODEL USED"
-          name="ai_feedback_model"
-          rules={[{ required: enableAiFeedback, message: "Please select an AI model" }]}
-        >
-          <Radio.Group disabled={!enableAiFeedback}>
-            <Space direction="vertical">
-              <Radio value="gpt-3.5-turbo">GPT-3.5 Turbo</Radio>
-              <Radio value="gpt-4o">GPT-4o</Radio>
-              <Radio value="custom-model">Custom Model</Radio>
-            </Space>
-          </Radio.Group>
-        </Form.Item> */}
+                      <Radio value={false}>
+                        Customize for this assignment only
+                      </Radio>
+                    </Space>
+                  </Radio.Group>
+                </Form.Item>
 
-        <Form.Item
-          label="MODEL TEMPERATURE"
-          name="ai_feedback_temperature"
-          rules={[
-            { required: enableAiFeedback, message: "Please enter a temperature" },
-            { pattern: /^0(\.\d+)?|1$/, message: "Enter a value between 0 and 1" }
-          ]}
-        >
-          <Input placeholder="Enter temperature (0 to 1)" disabled={!enableAiFeedback} />
-        </Form.Item>
+                {useCourseAiDefault === false && (
+                  <Card size="small" title="Custom Assignment Model">
+                    <Form.Item
+                      label="Provider"
+                      name="ai_feedback_provider"
+                      rules={[
+                        {
+                          required: true,
+                          message: "Please select an AI provider",
+                        },
+                      ]}
+                    >
+                      <Select
+                        options={[
+                          { label: "ChatGPT", value: "openai" },
+                          { label: "Gemini", value: "gemini" },
+                          { label: "Claude", value: "claude" },
+                        ]}
+                        onChange={() => {
+                          setAssignmentModels([]);
+                          form.setFieldsValue({ ai_feedback_model: undefined });
+                        }}
+                      />
+                    </Form.Item>
 
+                    <Form.Item
+                      label="Model"
+                      name="ai_feedback_model"
+                      rules={[
+                        {
+                          required: true,
+                          message: "Please fetch and select an AI model",
+                        },
+                      ]}
+                    >
+                      <Space.Compact style={{ width: "100%" }}>
+                        <Button
+                          onClick={handleFetchAssignmentModels}
+                          loading={assignmentModelsLoading}
+                          style={{ width: 180 }}
+                        >
+                          Fetch Models
+                        </Button>
+
+                        <Select
+                          placeholder="Select a model"
+                          style={{ width: "100%" }}
+                          disabled={assignmentModels.length === 0}
+                          options={assignmentModels.map((model) => ({
+                            label: model,
+                            value: model,
+                          }))}
+                        />
+                      </Space.Compact>
+                    </Form.Item>
+                  </Card>
+                )}
+
+               <Form.Item
+                label="Feedback Style"
+                name="ai_feedback_style"
+                initialValue="balanced"
+              >
+                <Select
+                  options={[
+                    { label: "Hint-based", value: "hint-based" },
+                    { label: "Balanced", value: "balanced" },
+                    { label: "Detailed debugging", value: "detailed-debugging" },
+                  ]}
+                />
+              </Form.Item>
+
+              <Form.Item
+                label="AI Feedback Prompt"
+                name="ai_feedback_prompt"
+                initialValue=""
+              >
+                <Input.TextArea
+                  placeholder="Optional. Leave blank to use the default correctness-only feedback prompt."
+                  autoSize={{ minRows: 4, maxRows: 8 }}
+                />
+              </Form.Item>
+
+                <Form.Item
+                  label="Model Temperature"
+                  name="ai_feedback_temperature"
+                  initialValue={0.5}
+                  rules={[
+                    {
+                      pattern: /^0(\.\d+)?|1$/,
+                      message: "Enter a value between 0 and 1",
+                    },
+                  ]}
+                >
+                  <Input placeholder="0.5" />
+                </Form.Item>
+              </>
+            )}
+          </Card>
 
           <Form.Item>
             <Space>
-              <Button type='primary' htmlType='submit'>
+              <Button type="primary" htmlType="submit">
                 Save
               </Button>
+
               <Popconfirm
                 title="Are you sure you want to delete this assignment?"
                 onConfirm={() => handleDeleteAssignment(assignmentId).then(navigateMainPage)}
                 okText="Yes"
-                cancelText="No">
-                <Button 
-                  danger type='primary' 
-                  icon={<DeleteOutlined />} >
+                cancelText="No"
+              >
+                <Button danger type="primary" icon={<DeleteOutlined />}>
                   Delete Assignment
                 </Button>
               </Popconfirm>
+
               <Popconfirm
                 title="Are you sure you want to delete all submissions?"
                 onConfirm={() => {
-                  handleDeleteSubmissions(assignmentId)
+                  handleDeleteSubmissions(assignmentId);
                 }}
                 okText="Yes"
-                cancelText="No">
-                <Button 
-                  danger type='primary' 
-                  icon={<DeleteOutlined />} >
+                cancelText="No"
+              >
+                <Button danger type="primary" icon={<DeleteOutlined />}>
                   Delete All Submissions
                 </Button>
               </Popconfirm>

--- a/frontend/src/pages/assignmentSettings/index.js
+++ b/frontend/src/pages/assignmentSettings/index.js
@@ -28,6 +28,33 @@ import {
 } from "../../services/assignment";
 import { getCourseInfo, fetchAiModels } from "../../services/course";
 import moment from "moment";
+const DEFAULT_AI_FEEDBACK_PROMPT = `You are giving short, student-facing feedback on a programming assignment.
+
+Focus only on correctness and debugging.
+
+Allowed feedback topics:
+- Incorrect logic
+- Missing required behavior
+- Failed test cases
+- Edge cases
+- Runtime errors
+- Incorrect input/output handling
+- Incorrect return values
+- Algorithm mistakes
+
+Do not comment on:
+- Style
+- Formatting
+- Naming
+- Indentation
+- Readability
+- Refactoring
+
+Rules:
+- Do not provide corrected code.
+- Do not give copy-paste fixes.
+- Do not reveal the final answer.
+- Give short hints that help the student investigate the bug.`;
 
 export default () => {
   const { assignmentId } = useParams();
@@ -99,7 +126,7 @@ export default () => {
         enableAiFeedback: !!ai_feedback_enabled,
         use_course_ai_default: use_course_ai_default !== false,
         ai_feedback_provider: ai_feedback_provider || "openai",
-        ai_feedback_prompt: ai_feedback_prompt || "",
+        ai_feedback_prompt: ai_feedback_prompt || DEFAULT_AI_FEEDBACK_PROMPT,
         ai_feedback_model: ai_feedback_model || undefined,
         ai_feedback_temperature: ai_feedback_temperature ?? 0.5,
         ai_feedback_style: ai_feedback_style || "balanced",
@@ -441,7 +468,6 @@ export default () => {
               <Form.Item
                 label="AI Feedback Prompt"
                 name="ai_feedback_prompt"
-                initialValue=""
               >
                 <Input.TextArea
                   placeholder="Optional. Leave blank to use the default correctness-only feedback prompt."

--- a/frontend/src/pages/assignmentSettings/index.js
+++ b/frontend/src/pages/assignmentSettings/index.js
@@ -48,6 +48,14 @@ export default () => {
 
   const useCourseAiDefault = Form.useWatch("use_course_ai_default", form);
 
+  useEffect(() => {
+    if (enableAiFeedback && !form.getFieldValue("ai_feedback_prompt")) {
+      form.setFieldsValue({
+        ai_feedback_prompt: DEFAULT_AI_FEEDBACK_PROMPT,
+      });
+    }
+  }, [enableAiFeedback, form]);
+
   const loadCourseAiInfo = useCallback(
     async (targetCourseId) => {
       if (!targetCourseId) {
@@ -136,10 +144,10 @@ export default () => {
         });
       }
 
-      message.success("Models fetched successfully");
+      message.success("Models refreshed successfully");
     } catch (e) {
       console.error("Failed to fetch models:", e.response?.data || e);
-      message.error(e.response?.data?.error || "Failed to fetch models");
+      message.error(e.response?.data?.error || "Failed to refresh models");
     } finally {
       setAssignmentModelsLoading(false);
     }
@@ -398,7 +406,7 @@ export default () => {
                       rules={[
                         {
                           required: true,
-                          message: "Please fetch and select an AI model",
+                          message: "Please refresh and select an AI model",
                         },
                       ]}
                     >
@@ -408,7 +416,7 @@ export default () => {
                           loading={assignmentModelsLoading}
                           style={{ width: 180 }}
                         >
-                          Fetch Models
+                          Refresh Models
                         </Button>
 
                         <Select

--- a/frontend/src/pages/assignmentSettings/index.js
+++ b/frontend/src/pages/assignmentSettings/index.js
@@ -28,33 +28,7 @@ import {
 } from "../../services/assignment";
 import { getCourseInfo, fetchAiModels } from "../../services/course";
 import moment from "moment";
-const DEFAULT_AI_FEEDBACK_PROMPT = `You are giving short, student-facing feedback on a programming assignment.
-
-Focus only on correctness and debugging.
-
-Allowed feedback topics:
-- Incorrect logic
-- Missing required behavior
-- Failed test cases
-- Edge cases
-- Runtime errors
-- Incorrect input/output handling
-- Incorrect return values
-- Algorithm mistakes
-
-Do not comment on:
-- Style
-- Formatting
-- Naming
-- Indentation
-- Readability
-- Refactoring
-
-Rules:
-- Do not provide corrected code.
-- Do not give copy-paste fixes.
-- Do not reveal the final answer.
-- Give short hints that help the student investigate the bug.`;
+import { DEFAULT_AI_FEEDBACK_PROMPT } from "../../constants/aiFeedback";
 
 export default () => {
   const { assignmentId } = useParams();
@@ -470,7 +444,7 @@ export default () => {
                 name="ai_feedback_prompt"
               >
                 <Input.TextArea
-                  placeholder="Optional. Leave blank to use the default correctness-only feedback prompt."
+                  placeholder="Default feedback prompt"
                   autoSize={{ minRows: 4, maxRows: 8 }}
                 />
               </Form.Item>

--- a/frontend/src/pages/instructor/aiSettings/index.js
+++ b/frontend/src/pages/instructor/aiSettings/index.js
@@ -23,7 +23,7 @@ import {
   Typography,
   message,
 } from "antd";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
   getCourseInfo,
@@ -51,6 +51,19 @@ const PROVIDER_DEFAULT_MODELS = {
   claude: "claude-3-5-sonnet-20241022",
 };
 
+const getKeyStatus = (course, selectedProviderKey) => {
+  if (selectedProviderKey === "openai") {
+    return !!course.has_openai_api_key;
+  }
+  if (selectedProviderKey === "gemini") {
+    return !!course.has_gemini_api_key;
+  }
+  if (selectedProviderKey === "claude") {
+    return !!course.has_claude_api_key;
+  }
+  return false;
+};
+
 export default function AISettings() {
   const { courseId } = useParams();
   const [form] = Form.useForm();
@@ -66,35 +79,57 @@ export default function AISettings() {
 
   const selectedProvider = PROVIDERS.find((item) => item.key === provider);
 
-  const getKeyStatus = (course, selectedProviderKey) => {
-    if (selectedProviderKey === "openai") {
-      return !!course.has_openai_api_key;
-    }
-    if (selectedProviderKey === "gemini") {
-      return !!course.has_gemini_api_key;
-    }
-    if (selectedProviderKey === "claude") {
-      return !!course.has_claude_api_key;
-    }
-    return false;
-  };
+  const fetchModelsForProvider = useCallback(async ({
+    targetProvider,
+    keyOverride = "",
+    currentModel = "",
+    silent = false,
+  } = {}) => {
+    try {
+      setModelsLoading(true);
 
-  const getProviderKeyValue = (course, selectedProviderKey) => {
-    if (selectedProviderKey === "openai") {
-      return course.openai_api_key_value || "";
-    }
+      const response = await fetchAiModels({
+        course_id: courseId,
+        provider: targetProvider,
+        api_key: keyOverride || undefined,
+      });
 
-    if (selectedProviderKey === "gemini") {
-      return course.gemini_api_key_value || "";
-    }
+      const fetchedModels = response?.data?.models || [];
+      setModels(fetchedModels);
 
-    if (selectedProviderKey === "claude") {
-      return course.claude_api_key_value || "";
-    }
+      if (fetchedModels.length === 0) {
+        if (!silent) {
+          message.warning("No models found for this provider");
+        }
+        return;
+      }
 
-    return "";
-  };
-  const loadCourseAiInfo = async () => {
+      const providerPreferredModel = PROVIDER_DEFAULT_MODELS[targetProvider];
+
+      const preferredModel =
+        providerPreferredModel && fetchedModels.includes(providerPreferredModel)
+          ? providerPreferredModel
+          : fetchedModels[0];
+
+      if (!currentModel || !fetchedModels.includes(currentModel)) {
+        setModelName(preferredModel);
+        form.setFieldsValue({ model_name: preferredModel });
+      }
+
+      if (!silent) {
+        message.success("Models refreshed successfully");
+      }
+    } catch (e) {
+      console.error("Failed to fetch models:", e.response?.data || e);
+      if (!silent) {
+        message.error(e.response?.data?.error || "Failed to refresh models");
+      }
+    } finally {
+      setModelsLoading(false);
+    }
+  }, [courseId, form]);
+
+  const loadCourseAiInfo = useCallback(async () => {
     try {
       const res = await getCourseInfo({ course_id: courseId });
       const course = res?.data?.[0] || {};
@@ -109,7 +144,7 @@ export default function AISettings() {
 
       setProvider(defaultProvider);
       setModelName(defaultModel);
-      setApiKey(getProviderKeyValue(course, defaultProvider));
+      setApiKey("");
 
       form.setFieldsValue({
         provider: defaultProvider,
@@ -117,79 +152,64 @@ export default function AISettings() {
         feedback_style: course.default_feedback_style || "balanced",
         temperature: course.default_ai_temperature ?? 0.5,
       });
+
+      if (getKeyStatus(course, defaultProvider)) {
+        await fetchModelsForProvider({
+          targetProvider: defaultProvider,
+          keyOverride: "",
+          currentModel: defaultModel,
+          silent: true,
+        });
+      }
     } catch (e) {
       console.error("Failed to load course AI settings:", e);
       message.error("Failed to load AI settings");
     }
-  };
+  }, [courseId, fetchModelsForProvider, form]);
+
   useEffect(() => {
     loadCourseAiInfo();
-  }, [courseId]);
+  }, [loadCourseAiInfo]);
 
-  const handleProviderChange = (newProvider) => {
+  const handleProviderChange = async (newProvider) => {
     setProvider(newProvider);
     setModels([]);
     setApiTestStatus(null);
 
-    const savedKey = getProviderKeyValue(courseAiInfo, newProvider);
     const fallbackModel = PROVIDER_DEFAULT_MODELS[newProvider] || "";
 
-    setApiKey(savedKey);
+    setApiKey("");
+
+    let nextModel = fallbackModel;
 
     if (newProvider === courseAiInfo.default_ai_provider) {
       const savedModel = courseAiInfo.default_ai_model || fallbackModel;
 
-      setModelName(savedModel);
-      form.setFieldsValue({
-        provider: newProvider,
-        model_name: savedModel,
-      });
-    } else {
-      setModelName(fallbackModel);
-      form.setFieldsValue({
-        provider: newProvider,
-        model_name: fallbackModel,
+      nextModel = savedModel;
+    }
+
+    setModelName(nextModel);
+    form.setFieldsValue({
+      provider: newProvider,
+      model_name: nextModel,
+    });
+
+    if (getKeyStatus(courseAiInfo, newProvider)) {
+      await fetchModelsForProvider({
+        targetProvider: newProvider,
+        keyOverride: "",
+        currentModel: nextModel,
+        silent: true,
       });
     }
   };
 
   const handleFetchModels = async () => {
-    try {
-      setModelsLoading(true);
-
-      const response = await fetchAiModels({
-        course_id: courseId,
-        provider,
-        api_key: apiKey || undefined,
-      });
-
-      const fetchedModels = response?.data?.models || [];
-      setModels(fetchedModels);
-
-      if (fetchedModels.length === 0) {
-        message.warning("No models found for this provider");
-        return;
-      }
-
-      const providerPreferredModel = PROVIDER_DEFAULT_MODELS[provider];
-
-      const preferredModel =
-        providerPreferredModel && fetchedModels.includes(providerPreferredModel)
-          ? providerPreferredModel
-          : fetchedModels[0];
-
-      if (!modelName || !fetchedModels.includes(modelName)) {
-        setModelName(preferredModel);
-        form.setFieldsValue({ model_name: preferredModel });
-      }
-
-      message.success("Models fetched successfully");
-    } catch (e) {
-      console.error("Failed to fetch models:", e.response?.data || e);
-      message.error(e.response?.data?.error || "Failed to fetch models");
-    } finally {
-      setModelsLoading(false);
-    }
+    await fetchModelsForProvider({
+      targetProvider: provider,
+      keyOverride: apiKey,
+      currentModel: modelName,
+    });
   };
 
   const testConnection = async () => {
@@ -201,7 +221,7 @@ export default function AISettings() {
       const selectedModel = values.model_name || modelName;
 
       if (!selectedModel) {
-        message.error("Please fetch models and select a model before testing");
+        message.error("Please refresh models and select a model before testing");
         setApiTestStatus("error");
         return;
       }
@@ -220,7 +240,7 @@ export default function AISettings() {
       setApiTestStatus("error");
       message.error(
         e.response?.data?.error ||
-          "Selected model cannot be used. Please fetch models and choose another model."
+          "Selected model cannot be used. Please refresh models and choose another model."
       );
     } finally {
       setIsTesting(false);
@@ -249,7 +269,6 @@ export default function AISettings() {
   };
 
   const hasSavedKey = getKeyStatus(courseAiInfo, provider);
-  const setupReady = hasSavedKey && !!modelName;
 
   return (
     <Layout style={{ background: "#fff", minHeight: "100%" }}>
@@ -285,38 +304,38 @@ export default function AISettings() {
               subTitle="Configure course default AI settings and provider keys"
             />
 
-            <Card title="AI Setup Status">
-              <Space direction="vertical" style={{ width: "100%" }}>
-                <Space>
-                  {setupReady ? (
-                    <Tag color="success" icon={<CheckCircleOutlined />}>
-                      Ready
-                    </Tag>
-                  ) : (
-                    <Tag color="warning" icon={<CloseCircleOutlined />}>
-                      Setup incomplete
-                    </Tag>
-                  )}
+            <Space wrap>
+              <Tag
+                color={hasSavedKey ? "success" : "warning"}
+                icon={hasSavedKey ? <CheckCircleOutlined /> : <CloseCircleOutlined />}
+              >
+                API key: {hasSavedKey ? "Connected" : "Not saved"}
+              </Tag>
 
-                  <Typography.Text>
-                    Default:{" "}
-                    <strong>
-                      {courseAiInfo.default_ai_provider || "Not selected"} /{" "}
-                      {courseAiInfo.default_ai_model || "No model selected"}
-                    </strong>
-                  </Typography.Text>
-                </Space>
-
-                {!hasSavedKey && (
-                  <Alert
-                    type="warning"
-                    showIcon
-                    message={`${selectedProvider?.label} API key is not saved`}
-                    description="Add and save an API key before using this provider for AI feedback."
-                  />
-                )}
-              </Space>
-            </Card>
+              <Tag
+                color={
+                  apiTestStatus === "success"
+                    ? "success"
+                    : apiTestStatus === "error"
+                    ? "error"
+                    : "default"
+                }
+                icon={
+                  apiTestStatus === "success" ? (
+                    <CheckCircleOutlined />
+                  ) : apiTestStatus === "error" ? (
+                    <CloseCircleOutlined />
+                  ) : null
+                }
+              >
+                Selected model:{" "}
+                {apiTestStatus === "success"
+                  ? "Tested successfully"
+                  : apiTestStatus === "error"
+                  ? "Test failed"
+                  : "Not tested"}
+              </Tag>
+            </Space>
 
             <Card
               title={
@@ -335,8 +354,8 @@ export default function AISettings() {
                 type="info"
                 showIcon
                 style={{ marginBottom: 16 }}
-                message="Fetch models before choosing"
-                description="Click Fetch Models first to load all available models for this provider. Before fetching, the dropdown may only show the currently saved/default model."
+                message="Refresh models before choosing"
+                description="Use Refresh Models to load the current usable models for this provider. A saved model may appear before the model list is refreshed."
               />
 
               <Form.Item label="Provider" name="provider">
@@ -356,7 +375,7 @@ export default function AISettings() {
                 rules={[
                   {
                     required: true,
-                    message: "Please fetch models and select a usable model",
+                    message: "Please refresh models and select a usable model",
                   },
                 ]}
               >
@@ -366,7 +385,7 @@ export default function AISettings() {
                     loading={modelsLoading}
                     style={{ width: 180 }}
                   >
-                    Fetch Models
+                    Refresh Models
                   </Button>
 
                   <Select
@@ -413,7 +432,7 @@ export default function AISettings() {
                   }
                   description={
                     hasSavedKey
-                      ? "Saved key is loaded into the password field and hidden by default. Use the visibility icon to view it."
+                      ? "A saved key exists. Paste a new key only if you want to replace it."
                       : "Paste an API key below and save it for this provider."
                   }
                 />
@@ -429,7 +448,7 @@ export default function AISettings() {
 
                 <Space>
                   <Button onClick={testConnection} disabled={isTesting}>
-                    Test Connection
+                    Test Selected Model
                   </Button>
 
                   {isTesting && (
@@ -442,13 +461,13 @@ export default function AISettings() {
 
                   {apiTestStatus === "success" && (
                     <Typography.Text type="success">
-                      <CheckCircleOutlined /> Connected successfully
+                      <CheckCircleOutlined /> Selected model tested successfully
                     </Typography.Text>
                   )}
 
                   {apiTestStatus === "error" && (
                     <Typography.Text type="danger">
-                      <CloseCircleOutlined /> Connection failed
+                      <CloseCircleOutlined /> Selected model test failed
                     </Typography.Text>
                   )}
                 </Space>

--- a/frontend/src/pages/instructor/aiSettings/index.js
+++ b/frontend/src/pages/instructor/aiSettings/index.js
@@ -1,200 +1,489 @@
-import { CheckCircleOutlined, CloseCircleOutlined, LoadingOutlined } from "@ant-design/icons";
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  LoadingOutlined,
+  KeyOutlined,
+  RobotOutlined,
+} from "@ant-design/icons";
 
 import {
+  Alert,
   Button,
   Card,
-  Layout,
-  Menu,
+  Divider,
   Form,
   Input,
+  Layout,
+  Menu,
   PageHeader,
+  Select,
   Space,
+  Spin,
+  Tag,
   Typography,
   message,
-  Spin
 } from "antd";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { getCourseInfo, storeApiKey } from "../../../services/course";
-import axios from "axios";
+import {
+  getCourseInfo,
+  updateAiSettings,
+  fetchAiModels,
+  testAiModel,
+} from "../../../services/course";
 
-export default () => {
+const { Sider, Content } = Layout;
+
+const PROVIDERS = [
+  { key: "openai", label: "ChatGPT", displayName: "OpenAI / ChatGPT" },
+  { key: "gemini", label: "Gemini", displayName: "Google Gemini" },
+  { key: "claude", label: "Claude", displayName: "Anthropic Claude" },
+];
+
+const FEEDBACK_STYLES = [
+  { label: "Hint-based", value: "hint-based" },
+  { label: "Balanced", value: "balanced" },
+  { label: "Detailed debugging", value: "detailed-debugging" },
+];
+const PROVIDER_DEFAULT_MODELS = {
+  openai: "gpt-4o-mini",
+  gemini: "gemini-1.5-flash",
+  claude: "claude-3-5-sonnet-20241022",
+};
+
+export default function AISettings() {
   const { courseId } = useParams();
   const [form] = Form.useForm();
 
-  // Sidebar providers list
-  const providers = [
-    { key: "openai", label: "ChatGPT" },
-    { key: "google", label: "Gemini" },
-    { key: "anthropic", label: "Claude" },
-  ];
-
   const [provider, setProvider] = useState("openai");
   const [apiKey, setApiKey] = useState("");
+  const [modelName, setModelName] = useState("");
+  const [models, setModels] = useState([]);
+  const [courseAiInfo, setCourseAiInfo] = useState({});
   const [isTesting, setIsTesting] = useState(false);
+  const [modelsLoading, setModelsLoading] = useState(false);
   const [apiTestStatus, setApiTestStatus] = useState(null);
 
+  const selectedProvider = PROVIDERS.find((item) => item.key === provider);
+
+  const getKeyStatus = (course, selectedProviderKey) => {
+    if (selectedProviderKey === "openai") {
+      return !!course.has_openai_api_key;
+    }
+    if (selectedProviderKey === "gemini") {
+      return !!course.has_gemini_api_key;
+    }
+    if (selectedProviderKey === "claude") {
+      return !!course.has_claude_api_key;
+    }
+    return false;
+  };
+
+  const getProviderKeyValue = (course, selectedProviderKey) => {
+    if (selectedProviderKey === "openai") {
+      return course.openai_api_key_value || "";
+    }
+
+    if (selectedProviderKey === "gemini") {
+      return course.gemini_api_key_value || "";
+    }
+
+    if (selectedProviderKey === "claude") {
+      return course.claude_api_key_value || "";
+    }
+
+    return "";
+  };
+  const loadCourseAiInfo = async () => {
+    try {
+      const res = await getCourseInfo({ course_id: courseId });
+      const course = res?.data?.[0] || {};
+
+      setCourseAiInfo(course);
+
+      const defaultProvider = course.default_ai_provider || "openai";
+      const defaultModel =
+        course.default_ai_model ||
+        PROVIDER_DEFAULT_MODELS[defaultProvider] ||
+        "";
+
+      setProvider(defaultProvider);
+      setModelName(defaultModel);
+      setApiKey(getProviderKeyValue(course, defaultProvider));
+
+      form.setFieldsValue({
+        provider: defaultProvider,
+        model_name: defaultModel,
+        feedback_style: course.default_feedback_style || "balanced",
+        temperature: course.default_ai_temperature ?? 0.5,
+      });
+    } catch (e) {
+      console.error("Failed to load course AI settings:", e);
+      message.error("Failed to load AI settings");
+    }
+  };
   useEffect(() => {
-    const load = async () => {
-      try {
-        const res = await getCourseInfo({ course_id: courseId });
-        const course = res?.data?.[0] || {};
-        form.setFieldsValue(course);
-        // initialize selected provider
-        const savedProvider = localStorage.getItem(`ai_selected_provider_${courseId}`) || "openai";
-        setProvider(savedProvider);
+    loadCourseAiInfo();
+  }, [courseId]);
 
-        // preload OpenAI key from backend column if provider is openai
-        const backendOpenAiKey = course.openai_api_key || "";
-        const storedProviderKey = localStorage.getItem(`ai_key_${savedProvider}_${courseId}`) || "";
-        setApiKey(savedProvider === "openai" ? (backendOpenAiKey || storedProviderKey) : storedProviderKey);
+  const handleProviderChange = (newProvider) => {
+    setProvider(newProvider);
+    setModels([]);
+    setApiTestStatus(null);
 
-      } catch (e) {
-        console.error(e);
+    const savedKey = getProviderKeyValue(courseAiInfo, newProvider);
+    const fallbackModel = PROVIDER_DEFAULT_MODELS[newProvider] || "";
+
+    setApiKey(savedKey);
+
+    if (newProvider === courseAiInfo.default_ai_provider) {
+      const savedModel = courseAiInfo.default_ai_model || fallbackModel;
+
+      setModelName(savedModel);
+      form.setFieldsValue({
+        provider: newProvider,
+        model_name: savedModel,
+      });
+    } else {
+      setModelName(fallbackModel);
+      form.setFieldsValue({
+        provider: newProvider,
+        model_name: fallbackModel,
+      });
+    }
+  };
+
+  const handleFetchModels = async () => {
+    try {
+      setModelsLoading(true);
+
+      const response = await fetchAiModels({
+        course_id: courseId,
+        provider,
+        api_key: apiKey || undefined,
+      });
+
+      const fetchedModels = response?.data?.models || [];
+      setModels(fetchedModels);
+
+      if (fetchedModels.length === 0) {
+        message.warning("No models found for this provider");
+        return;
       }
-    };
-    load();
-  }, [courseId, form]);
+
+      const providerPreferredModel = PROVIDER_DEFAULT_MODELS[provider];
+
+      const preferredModel =
+        providerPreferredModel && fetchedModels.includes(providerPreferredModel)
+          ? providerPreferredModel
+          : fetchedModels[0];
+
+      if (!modelName || !fetchedModels.includes(modelName)) {
+        setModelName(preferredModel);
+        form.setFieldsValue({ model_name: preferredModel });
+      }
+
+      message.success("Models fetched successfully");
+    } catch (e) {
+      console.error("Failed to fetch models:", e.response?.data || e);
+      message.error(e.response?.data?.error || "Failed to fetch models");
+    } finally {
+      setModelsLoading(false);
+    }
+  };
+
+  const testConnection = async () => {
+    try {
+      setIsTesting(true);
+      setApiTestStatus(null);
+
+      const values = form.getFieldsValue();
+      const selectedModel = values.model_name || modelName;
+
+      if (!selectedModel) {
+        message.error("Please fetch models and select a model before testing");
+        setApiTestStatus("error");
+        return;
+      }
+
+      await testAiModel({
+        course_id: courseId,
+        provider,
+        model: selectedModel,
+        api_key: apiKey || undefined,
+      });
+
+      setApiTestStatus("success");
+      message.success("Selected model can be used successfully");
+    } catch (e) {
+      console.error("Selected model test failed:", e.response?.data || e);
+      setApiTestStatus("error");
+      message.error(
+        e.response?.data?.error ||
+          "Selected model cannot be used. Please fetch models and choose another model."
+      );
+    } finally {
+      setIsTesting(false);
+    }
+  };
 
   const handleSave = async () => {
     try {
-      // persist current selection and per-provider settings
-      localStorage.setItem(`ai_selected_provider_${courseId}`, provider);
+      const values = await form.validateFields();
 
-      if (provider === "openai") {
-        await storeApiKey({
-          course_id: courseId,
-          api_key: apiKey,
-        });
+      await updateAiSettings({
+        course_id: courseId,
+        provider,
+        model_name: values.model_name,
+        api_key: apiKey || undefined,
+        feedback_style: values.feedback_style,
+        temperature: values.temperature,
+      });
 
-        // also mirror into local storage for consistency
-        localStorage.setItem(`ai_key_${provider}_${courseId}`, apiKey);
-      } else {
-        // temporarily cache non-openai keys in localStorage
-        localStorage.setItem(`ai_key_${provider}_${courseId}`, apiKey);
-      }
-
-      message.success("AI settings saved");
+      message.success("Course AI settings saved");
+      await loadCourseAiInfo();
     } catch (e) {
       console.error("Failed to save AI settings:", e.response?.data || e);
       message.error(e.response?.data?.error || "Failed to save AI settings");
     }
   };
 
-  const testConnection = async () => {
-    setIsTesting(true);
-    setApiTestStatus(null);
-    try {
-      if (!apiKey) {
-        message.error("Enter API key first");
-        setApiTestStatus("error");
-        return;
-      }
-      let ok = false;
-      if (provider === "openai") {
-        const response = await axios.get("https://api.openai.com/v1/models", {
-          headers: { Authorization: `Bearer ${apiKey}` },
-        });
-        ok = response.status === 200;
-      } else if (provider === "google") {
-        // Gemini models listing
-        const response = await axios.get(
-          "https://generativelanguage.googleapis.com/v1beta/models",
-          { params: { key: apiKey } }
-        );
-        ok = response.status === 200;
-      } else if (provider === "anthropic") {
-        // Claude models listing (simple ping via models is not public; do a harmless messages call with empty content)
-        const response = await axios.post(
-          "https://api.anthropic.com/v1/messages",
-          { model: "claude-3-5-sonnet", max_tokens: 1, messages: [{ role: "user", content: "ping" }] },
-          { headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" } }
-        );
-        ok = response.status >= 200 && response.status < 300;
-      }
-      if (ok) {
-        setApiTestStatus("success");
-        message.success("Connected successfully!");
-      } else {
-        setApiTestStatus("error");
-        message.error("Connection failed. Check your key.");
-      }
-    } catch (e) {
-      setApiTestStatus("error");
-      message.error("Connection failed. Check your key.");
-    } finally {
-      setIsTesting(false);
-    }
-  };
-
-  const handleSelectProvider = async (e) => {
-    const newProvider = e.key;
-    setProvider(newProvider);
-    // load key for provider; prefer backend for openai if present
-    try {
-      if (newProvider === "openai") {
-        const res = await getCourseInfo({ course_id: courseId });
-        const course = res?.data?.[0] || {};
-        const backendOpenAiKey = course.openai_api_key || "";
-        const storedProviderKey = localStorage.getItem(`ai_key_${newProvider}_${courseId}`) || "";
-        setApiKey(backendOpenAiKey || storedProviderKey);
-      } else {
-        const storedProviderKey = localStorage.getItem(`ai_key_${newProvider}_${courseId}`) || "";
-        setApiKey(storedProviderKey);
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  const { Sider, Content } = Layout;
+  const hasSavedKey = getKeyStatus(courseAiInfo, provider);
+  const setupReady = hasSavedKey && !!modelName;
 
   return (
-    <Layout style={{ background: '#fff', height: '100%', minHeight: '100%' }}>
-      <Sider width={260} style={{ background: '#fff', borderRight: '1px solid #f0f2f5' }}>
-        <div style={{ padding: '16px' }}>
-          <Typography.Title level={4} style={{ margin: 0 }}>AI Providers</Typography.Title>
+    <Layout style={{ background: "#fff", minHeight: "100%" }}>
+      <Sider
+        width={260}
+        style={{ background: "#fff", borderRight: "1px solid #f0f2f5" }}
+      >
+        <div style={{ padding: "16px" }}>
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            AI Providers
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            Select a provider to configure.
+          </Typography.Text>
         </div>
+
         <Menu
           mode="inline"
           selectedKeys={[provider]}
-          onClick={handleSelectProvider}
-          items={providers.map(p => ({ key: p.key, label: p.label }))}
+          onClick={(item) => handleProviderChange(item.key)}
+          items={PROVIDERS.map((item) => ({
+            key: item.key,
+            label: item.label,
+          }))}
         />
       </Sider>
-      <Content style={{ padding: '0 24px' }}>
-        <Form form={form} layout="vertical" style={{ marginLeft: "0px", paddingBottom: '24px' }}>
-          <Space direction="vertical" style={{ width: "100%" }}>
-            <PageHeader title="AI Settings" subTitle={providers.find(p => p.key === provider)?.label} />
-            <Card title="Credentials">
-              <Form.Item label="API Key">
-                <Input.Password value={apiKey} onChange={(e) => setApiKey(e.target.value)} placeholder="Enter API key" />
-              </Form.Item>
-            </Card>
-            <Card title="Connection Test">
-              <Space>
-                <Button type="primary" onClick={testConnection} disabled={isTesting}>Test Connection</Button>
-                {isTesting && <Spin indicator={<LoadingOutlined style={{ fontSize: 16 }} spin />} />}
-                {apiTestStatus === "success" && (
-                  <Typography.Text type="success">
-                    <CheckCircleOutlined style={{ marginLeft: 10 }} /> Connected successfully!
+
+      <Content style={{ padding: "0 24px 24px" }}>
+        <Form form={form} layout="vertical">
+          <Space direction="vertical" style={{ width: "100%" }} size="large">
+            <PageHeader
+              title="AI Settings"
+              subTitle="Configure course default AI settings and provider keys"
+            />
+
+            <Card title="AI Setup Status">
+              <Space direction="vertical" style={{ width: "100%" }}>
+                <Space>
+                  {setupReady ? (
+                    <Tag color="success" icon={<CheckCircleOutlined />}>
+                      Ready
+                    </Tag>
+                  ) : (
+                    <Tag color="warning" icon={<CloseCircleOutlined />}>
+                      Setup incomplete
+                    </Tag>
+                  )}
+
+                  <Typography.Text>
+                    Default:{" "}
+                    <strong>
+                      {courseAiInfo.default_ai_provider || "Not selected"} /{" "}
+                      {courseAiInfo.default_ai_model || "No model selected"}
+                    </strong>
                   </Typography.Text>
-                )}
-                {apiTestStatus === "error" && (
-                  <Typography.Text type="danger">
-                    <CloseCircleOutlined style={{ marginLeft: 10 }} /> Connection failed. Check your key.
-                  </Typography.Text>
+                </Space>
+
+                {!hasSavedKey && (
+                  <Alert
+                    type="warning"
+                    showIcon
+                    message={`${selectedProvider?.label} API key is not saved`}
+                    description="Add and save an API key before using this provider for AI feedback."
+                  />
                 )}
               </Space>
             </Card>
-            <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
-              <Button type="primary" onClick={handleSave}>Save Settings</Button>
+
+            <Card
+              title={
+                <Space>
+                  <RobotOutlined />
+                  <span>Course Default Model</span>
+                </Space>
+              }
+            >
+              <Typography.Paragraph type="secondary">
+                This provider and model will be used by assignments unless an
+                assignment chooses custom AI settings.
+              </Typography.Paragraph>
+
+              <Alert
+                type="info"
+                showIcon
+                style={{ marginBottom: 16 }}
+                message="Fetch models before choosing"
+                description="Click Fetch Models first to load all available models for this provider. Before fetching, the dropdown may only show the currently saved/default model."
+              />
+
+              <Form.Item label="Provider" name="provider">
+                <Select
+                  value={provider}
+                  onChange={handleProviderChange}
+                  options={PROVIDERS.map((item) => ({
+                    label: item.displayName,
+                    value: item.key,
+                  }))}
+                />
+              </Form.Item>
+
+              <Form.Item
+                label="Default Model"
+                name="model_name"
+                rules={[
+                  {
+                    required: true,
+                    message: "Please fetch models and select a usable model",
+                  },
+                ]}
+              >
+                <Space.Compact style={{ width: "100%" }}>
+                  <Button
+                    onClick={handleFetchModels}
+                    loading={modelsLoading}
+                    style={{ width: 180 }}
+                  >
+                    Fetch Models
+                  </Button>
+
+                  <Select
+                    value={modelName || undefined}
+                    onChange={(value) => {
+                      setModelName(value);
+                      form.setFieldsValue({ model_name: value });
+                    }}
+                    placeholder="Select a model"
+                    style={{ width: "100%" }}
+                    disabled={models.length === 0 && !modelName}
+                    options={[
+                      ...(modelName
+                        ? [{ label: modelName, value: modelName }]
+                        : []),
+                      ...models
+                        .filter((item) => item !== modelName)
+                        .map((item) => ({
+                          label: item,
+                          value: item,
+                        })),
+                    ]}
+                  />
+                </Space.Compact>
+              </Form.Item>
+            </Card>
+
+            <Card
+              title={
+                <Space>
+                  <KeyOutlined />
+                  <span>Provider API Key</span>
+                </Space>
+              }
+            >
+              <Space direction="vertical" style={{ width: "100%" }}>
+                <Alert
+                  type={hasSavedKey ? "success" : "info"}
+                  showIcon
+                  message={
+                    hasSavedKey
+                      ? `${selectedProvider?.label} API key is saved`
+                      : `${selectedProvider?.label} API key is not configured`
+                  }
+                  description={
+                    hasSavedKey
+                      ? "Saved key is loaded into the password field and hidden by default. Use the visibility icon to view it."
+                      : "Paste an API key below and save it for this provider."
+                  }
+                />
+
+                <Form.Item label="Add or Replace API Key">
+                  <Input.Password
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder="Paste a new API key to add or replace"
+                    visibilityToggle
+                  />
+                </Form.Item>
+
+                <Space>
+                  <Button onClick={testConnection} disabled={isTesting}>
+                    Test Connection
+                  </Button>
+
+                  {isTesting && (
+                    <Spin
+                      indicator={
+                        <LoadingOutlined style={{ fontSize: 16 }} spin />
+                      }
+                    />
+                  )}
+
+                  {apiTestStatus === "success" && (
+                    <Typography.Text type="success">
+                      <CheckCircleOutlined /> Connected successfully
+                    </Typography.Text>
+                  )}
+
+                  {apiTestStatus === "error" && (
+                    <Typography.Text type="danger">
+                      <CloseCircleOutlined /> Connection failed
+                    </Typography.Text>
+                  )}
+                </Space>
+              </Space>
+            </Card>
+
+            <Card title="Feedback Defaults">
+              <Form.Item label="Feedback Style" name="feedback_style">
+                <Select options={FEEDBACK_STYLES} />
+              </Form.Item>
+
+              <Form.Item
+                label="Temperature"
+                name="temperature"
+                rules={[
+                  {
+                    pattern: /^0(\.\d+)?|1$/,
+                    message: "Enter a value between 0 and 1",
+                  },
+                ]}
+              >
+                <Input placeholder="0.5" />
+              </Form.Item>
+            </Card>
+
+            <Divider />
+
+            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+              <Button type="primary" onClick={handleSave}>
+                Save Course Default
+              </Button>
             </div>
           </Space>
         </Form>
       </Content>
     </Layout>
   );
-};
-
-
+}

--- a/frontend/src/pages/instructor/aiSettings/index.js
+++ b/frontend/src/pages/instructor/aiSettings/index.js
@@ -15,7 +15,7 @@ import {
 } from "antd";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import {  getCourseInfo, storeApiKey } from "../../../services/course";
+import { getCourseInfo, storeApiKey } from "../../../services/course";
 import axios from "axios";
 
 export default () => {
@@ -31,7 +31,6 @@ export default () => {
 
   const [provider, setProvider] = useState("openai");
   const [apiKey, setApiKey] = useState("");
-  const [modelName, setModelName] = useState("");
   const [isTesting, setIsTesting] = useState(false);
   const [apiTestStatus, setApiTestStatus] = useState(null);
 
@@ -50,9 +49,6 @@ export default () => {
         const storedProviderKey = localStorage.getItem(`ai_key_${savedProvider}_${courseId}`) || "";
         setApiKey(savedProvider === "openai" ? (backendOpenAiKey || storedProviderKey) : storedProviderKey);
 
-        // per-provider model name
-        const savedModelName = localStorage.getItem(`ai_model_name_${savedProvider}_${courseId}`) || "";
-        setModelName(savedModelName);
       } catch (e) {
         console.error(e);
       }
@@ -64,7 +60,6 @@ export default () => {
     try {
       // persist current selection and per-provider settings
       localStorage.setItem(`ai_selected_provider_${courseId}`, provider);
-      localStorage.setItem(`ai_model_name_${provider}_${courseId}`, modelName);
 
       if (provider === "openai") {
         await storeApiKey({
@@ -132,7 +127,7 @@ export default () => {
     }
   };
 
-  const handleSelectModel = async (e) => {
+  const handleSelectProvider = async (e) => {
     const newProvider = e.key;
     setProvider(newProvider);
     // load key for provider; prefer backend for openai if present
@@ -150,8 +145,6 @@ export default () => {
     } catch (e) {
       console.error(e);
     }
-    const savedModelName = localStorage.getItem(`ai_model_name_${newProvider}_${courseId}`) || "";
-    setModelName(savedModelName);
   };
 
   const { Sider, Content } = Layout;
@@ -160,12 +153,12 @@ export default () => {
     <Layout style={{ background: '#fff', height: '100%', minHeight: '100%' }}>
       <Sider width={260} style={{ background: '#fff', borderRight: '1px solid #f0f2f5' }}>
         <div style={{ padding: '16px' }}>
-          <Typography.Title level={4} style={{ margin: 0 }}>AI Models</Typography.Title>
+          <Typography.Title level={4} style={{ margin: 0 }}>AI Providers</Typography.Title>
         </div>
         <Menu
           mode="inline"
           selectedKeys={[provider]}
-          onClick={handleSelectModel}
+          onClick={handleSelectProvider}
           items={providers.map(p => ({ key: p.key, label: p.label }))}
         />
       </Sider>
@@ -176,11 +169,6 @@ export default () => {
             <Card title="Credentials">
               <Form.Item label="API Key">
                 <Input.Password value={apiKey} onChange={(e) => setApiKey(e.target.value)} placeholder="Enter API key" />
-              </Form.Item>
-            </Card>
-            <Card title="Model">
-              <Form.Item label="Model Name (e.g., gpt-5o, gemini-1.5-pro, claude-3-5-sonnet)">
-                <Input value={modelName} onChange={(e) => setModelName(e.target.value)} placeholder="Enter model name" />
               </Form.Item>
             </Card>
             <Card title="Connection Test">

--- a/frontend/src/pages/instructor/assignments/CreateAssignment.js
+++ b/frontend/src/pages/instructor/assignments/CreateAssignment.js
@@ -36,7 +36,33 @@ import TestResultsDisplay from "../../result/TestResultsDisplay";
 import { uploadAssignmentAutograder } from "../../../services/submission";
 import { createAssignment, updateAssignment } from "../../../services/assignment";
 import { getCourseInfo, fetchAiModels } from "../../../services/course";
+const DEFAULT_AI_FEEDBACK_PROMPT = `You are giving short, student-facing feedback on a programming assignment.
 
+Focus only on correctness and debugging.
+
+Allowed feedback topics:
+- Incorrect logic
+- Missing required behavior
+- Failed test cases
+- Edge cases
+- Runtime errors
+- Incorrect input/output handling
+- Incorrect return values
+- Algorithm mistakes
+
+Do not comment on:
+- Style
+- Formatting
+- Naming
+- Indentation
+- Readability
+- Refactoring
+
+Rules:
+- Do not provide corrected code.
+- Do not give copy-paste fixes.
+- Do not reveal the final answer.
+- Give short hints that help the student investigate the bug.`;
 const { Sider, Content } = Layout;
 
 export default ({

--- a/frontend/src/pages/instructor/assignments/CreateAssignment.js
+++ b/frontend/src/pages/instructor/assignments/CreateAssignment.js
@@ -64,6 +64,14 @@ export default ({
   const { courseId } = useParams();
 
   useEffect(() => {
+    if (aiFeedbackEnabled && !form.getFieldValue("ai_feedback_prompt")) {
+      form.setFieldsValue({
+        ai_feedback_prompt: DEFAULT_AI_FEEDBACK_PROMPT,
+      });
+    }
+  }, [aiFeedbackEnabled, form]);
+
+  useEffect(() => {
     const loadCourseAiInfo = async () => {
       try {
         const res = await getCourseInfo({ course_id: courseId });
@@ -123,10 +131,10 @@ export default ({
         });
       }
 
-      message.success("Models fetched successfully");
+      message.success("Models refreshed successfully");
     } catch (e) {
       console.error("Failed to fetch models:", e.response?.data || e);
-      message.error(e.response?.data?.error || "Failed to fetch models");
+      message.error(e.response?.data?.error || "Failed to refresh models");
     } finally {
       setAssignmentModelsLoading(false);
     }
@@ -548,7 +556,7 @@ export default ({
                                 rules={[
                                   {
                                     required: true,
-                                    message: "Please fetch and select an AI model",
+                                    message: "Please refresh and select an AI model",
                                   },
                                 ]}
                               >
@@ -558,7 +566,7 @@ export default ({
                                     loading={assignmentModelsLoading}
                                     style={{ width: 180 }}
                                   >
-                                    Fetch Models
+                                    Refresh Models
                                   </Button>
 
                                   <Select

--- a/frontend/src/pages/instructor/assignments/CreateAssignment.js
+++ b/frontend/src/pages/instructor/assignments/CreateAssignment.js
@@ -6,6 +6,7 @@ import {
   UploadOutlined,
 } from "@ant-design/icons";
 import {
+  Alert,
   Button,
   Card,
   Checkbox,
@@ -25,7 +26,7 @@ import {
   Switch,
   message,
 } from "antd";
-import { useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import moment from "moment";
 
@@ -34,31 +35,9 @@ import TestAutograder from "../../configureAutograder/TestAutograder";
 import TestResultsDisplay from "../../result/TestResultsDisplay";
 import { uploadAssignmentAutograder } from "../../../services/submission";
 import { createAssignment, updateAssignment } from "../../../services/assignment";
+import { getCourseInfo, fetchAiModels } from "../../../services/course";
 
 const { Sider, Content } = Layout;
-const LLM_OPTIONS = [
-  { label: "GPT-3.5 Turbo", value: "gpt-3.5-turbo" },
-  { label: "GPT-4o", value: "gpt-4o" },
-  { label: "Custom Model", value: "custom-model" },
-];
-
-const AICheckbox = ({ value, onChange, options, disabled }) => {
-  const current = value ? [value] : [];
-
-  const handleChange = (vals) => {
-    const next = vals.length ? vals[vals.length - 1] : undefined;
-    onChange?.(next);
-  }
-
-  return (
-    <Checkbox.Group
-      options={options}
-      value={current}
-      disabled={disabled}
-      onChange={handleChange}
-    />
-  );
-};
 
 export default ({
   currentStep,
@@ -69,7 +48,8 @@ export default ({
 }) => {
   const [assignmentType, setAssignmentType] = useState(0);
   const aiFeedbackEnabled = Form.useWatch("ai_feedback_enabled", form);
-  
+  const useCourseAiDefault = Form.useWatch("use_course_ai_default", form);
+
   const [configureAutograderNow, setConfigureAutograderNow] = useState(false);
   const [autograderFile, setAutograderFile] = useState(null);
   const [saveLoading, setSaveLoading] = useState(false);
@@ -77,48 +57,133 @@ export default ({
   const [resultsModalOpen, setResultsModalOpen] = useState(false);
   const [testResultsData, setTestResultsData] = useState(null);
 
+  const [courseAiInfo, setCourseAiInfo] = useState({});
+  const [assignmentModels, setAssignmentModels] = useState([]);
+  const [assignmentModelsLoading, setAssignmentModelsLoading] = useState(false);
+
   const { courseId } = useParams();
-  
+
+  useEffect(() => {
+    const loadCourseAiInfo = async () => {
+      try {
+        const res = await getCourseInfo({ course_id: courseId });
+        const course = res?.data?.[0] || {};
+
+        setCourseAiInfo(course);
+
+        form.setFieldsValue({
+          use_course_ai_default: true,
+          ai_feedback_provider: course.default_ai_provider || "openai",
+          ai_feedback_model: course.default_ai_model || undefined,
+          ai_feedback_style: course.default_feedback_style || "balanced",
+          ai_feedback_prompt: "",
+          ai_feedback_temperature: course.default_ai_temperature ?? 0.5,
+        });
+      } catch (e) {
+        console.error("Failed to load course AI settings:", e);
+      }
+    };
+
+    if (courseId) {
+      loadCourseAiInfo();
+    }
+  }, [courseId, form]);
+
   const openTest = useCallback(() => setModalOpen(true), []);
   const closeTest = useCallback(() => setModalOpen(false), []);
+
   const handleAutograderSuccess = (data) => {
     setTestResultsData(data);
     setResultsModalOpen(true);
   };
+
   const handleCloseResultsModal = () => setResultsModalOpen(false);
+
+  const handleFetchAssignmentModels = async () => {
+    const provider = form.getFieldValue("ai_feedback_provider") || "openai";
+
+    try {
+      setAssignmentModelsLoading(true);
+
+      const response = await fetchAiModels({
+        course_id: courseId,
+        provider,
+      });
+
+      const fetchedModels = response?.data?.models || [];
+      setAssignmentModels(fetchedModels);
+
+      if (fetchedModels.length > 0) {
+        const preferredModel = fetchedModels.includes(courseAiInfo.default_ai_model)
+          ? courseAiInfo.default_ai_model
+          : fetchedModels[0];
+
+        form.setFieldsValue({
+          ai_feedback_model: preferredModel,
+        });
+      }
+
+      message.success("Models fetched successfully");
+    } catch (e) {
+      console.error("Failed to fetch models:", e.response?.data || e);
+      message.error(e.response?.data?.error || "Failed to fetch models");
+    } finally {
+      setAssignmentModelsLoading(false);
+    }
+  };
 
   const handleFinish = async (values) => {
     try {
       setSaveLoading(true);
+
       if (!courseId) {
         throw new Error("Missing courseId in route. Unable to create assignment.");
       }
 
       const toIso = (d) => (d ? new Date(d.valueOf()).toISOString() : null);
       const now = new Date();
-      const releaseDate = values.releaseDate ? new Date(values.releaseDate.valueOf()) : null;
+      const releaseDate = values.releaseDate
+        ? new Date(values.releaseDate.valueOf())
+        : null;
 
       const payload = {
-      name: values.name,
-      course_id: courseId,
-      published_date: toIso(values.releaseDate),
-      published: releaseDate ? releaseDate <= now : false,
-      due_date: toIso(values.dueDate),
-      late_due_date: toIso(values.lateDueDate),
-      late_submission: !!values.allowLateSubmissions,
-      enable_group: !!values.groupSubmission, 
-      group_size: values.limitGroupSize ? Number(values.limitGroupSize) : null,
-      manual_grading: !!values.manualGrading,
-      autograder_points: values.autograderPoints ? Number(values.autograderPoints) : null,
-      ai_feedback_enabled: !!values.ai_feedback_enabled,
-      ai_feedback_prompt: values.ai_feedback_prompt ?? null,
-      ai_feedback_model: values.ai_feedback_model ?? null,
-      ai_feedback_temperature: values.ai_feedback_temperature ?? null,
-    };
+        name: values.name,
+        course_id: courseId,
+        published_date: toIso(values.releaseDate),
+        published: releaseDate ? releaseDate <= now : false,
+        due_date: toIso(values.dueDate),
+        late_due_date: toIso(values.lateDueDate),
+        late_submission: !!values.allowLateSubmissions,
+        enable_group: !!values.groupSubmission,
+        group_size: values.limitGroupSize ? Number(values.limitGroupSize) : null,
+        manual_grading: !!values.manualGrading,
+        autograder_points: values.autograderPoints
+          ? Number(values.autograderPoints)
+          : null,
 
-    const assignment = await createAssignment(payload);
+        ai_feedback_enabled: !!values.ai_feedback_enabled,
+        use_course_ai_default: values.use_course_ai_default !== false,
+        ai_feedback_provider:
+          values.use_course_ai_default === false
+            ? values.ai_feedback_provider
+            : null,
+        ai_feedback_model:
+          values.use_course_ai_default === false
+            ? values.ai_feedback_model
+            : null,
+        ai_feedback_prompt: values.ai_feedback_prompt ?? null,
+        ai_feedback_temperature: values.ai_feedback_temperature ?? null,
+        ai_feedback_style: values.ai_feedback_style ?? null,
+      };
 
-      const assignmentId = assignment?.id ?? assignment?.data?.id ?? assignment?.assignment_id ?? assignment?.data?.assignment_id;
+      const assignment = await createAssignment(payload);
+
+      const assignmentId =
+        assignment?.id ??
+        assignment?.data?.id ??
+        assignment?.assignment_id ??
+        assignment?.data?.assignment_id;
+
       if (!assignmentId) {
         throw new Error("Backend did not return an assignment id.");
       }
@@ -132,24 +197,33 @@ export default ({
         });
 
         const op = values?.autograder?.operation;
+
         if (op === "zip") {
-          if (!autograderFile) throw new Error("Please choose an autograder .zip file.");
+          if (!autograderFile) {
+            throw new Error("Please choose an autograder .zip file.");
+          }
+
           const fd = new FormData();
           fd.append("assignment_id", assignmentId);
           fd.append("file", autograderFile);
-          fd.append("autograder_timeout", String(values?.autograder?.timeout || "300"));
+          fd.append(
+            "autograder_timeout",
+            String(values?.autograder?.timeout || "300")
+          );
+
           if (values?.autograder?.baseImageOS) {
             fd.append("base_image_os", values.autograder.baseImageOS);
             fd.append("base_image_version", values.autograder.baseImageVersion || "");
             fd.append("base_image_variant", values.autograder.baseImageVariant || "");
           }
+
           await uploadAssignmentAutograder(fd);
         }
-        // else if (op === "docker")
       }
 
       message.success("Assignment created");
       form.resetFields();
+
       if (typeof toggleIsCreate === "function") {
         toggleIsCreate();
       }
@@ -161,7 +235,6 @@ export default ({
     }
   };
 
-
   return (
     <>
       <Steps
@@ -172,29 +245,22 @@ export default ({
           { title: "Assignment Settings", status: "process" },
         ]}
       />
+
       {currentStep === 0 ? (
         <Card bordered={false}>
           <Typography.Link onClick={toggleIsCreate}>
             <LeftCircleFilled />
             <span> Exit</span>
           </Typography.Link>
+
           <Typography.Title level={5}>ASSIGNMENT TYPES</Typography.Title>
+
           <Menu
             onClick={({ key }) => {
               setAssignmentType(key);
               updateCurrentStep(1);
             }}
             items={[
-              // {
-              //   label: "Exam / Quiz",
-              //   key: 0,
-              //   icon: <FileTextOutlined />,
-              // },
-              // {
-              //   label: "Homework / Problem Set",
-              //   key: 1,
-              //   icon: <BookOutlined />,
-              // },
               {
                 label: "Programming Assignment",
                 key: 2,
@@ -216,7 +282,9 @@ export default ({
                 <LeftCircleFilled />
                 <span> Go Back</span>
               </Typography.Link>
+
               <Typography.Title level={5}>ASSIGNMENT TYPE</Typography.Title>
+
               {assignmentType === "0" ? (
                 <div>
                   <FileTextOutlined />
@@ -235,16 +303,21 @@ export default ({
               )}
             </Card>
           </Sider>
+
           <Content>
             <Card bordered={false}>
               <Form
                 layout="vertical"
                 form={form}
                 initialValues={{
-                  releaseDate: moment(), // current date
-                  dueDate: moment().add(7, "day"), // 7 days from now
+                  releaseDate: moment(),
+                  dueDate: moment().add(7, "day"),
                   autograderPoints: "100",
                   autograder: { operation: "zip", timeout: "300" },
+                  use_course_ai_default: true,
+                  ai_feedback_style: "balanced",
+                  ai_feedback_prompt: "",
+                  ai_feedback_temperature: 0.5,
                 }}
                 onFinish={handleFinish}
               >
@@ -258,11 +331,7 @@ export default ({
                 </Form.Item>
 
                 {assignmentType !== "2" ? (
-                  <Form.Item
-                    label="TEMPLATE"
-                    name="template"
-                    valuePropName="fileList"
-                  >
+                  <Form.Item label="TEMPLATE" name="template" valuePropName="fileList">
                     <Upload>
                       <Button icon={<UploadOutlined />}>select PDF</Button>
                     </Upload>
@@ -281,6 +350,7 @@ export default ({
                     >
                       <Input />
                     </Form.Item>
+
                     <Form.Item
                       label="MANUAL GRADING"
                       name="manualGrading"
@@ -290,10 +360,7 @@ export default ({
                     </Form.Item>
                   </>
                 ) : (
-                  <Form.Item
-                    label="WHO WILL UPLOAD SUBMISSIONS?"
-                    name="identify"
-                  >
+                  <Form.Item label="WHO WILL UPLOAD SUBMISSIONS?" name="identify">
                     <Radio.Group options={["Instructor", "Student"]} />
                   </Form.Item>
                 )}
@@ -306,20 +373,32 @@ export default ({
                           <Form.Item
                             label="RELEASE DATE (CDT)"
                             name="releaseDate"
-                            rules={[{ required: true, message: "Please select a release date" }]}
+                            rules={[
+                              {
+                                required: true,
+                                message: "Please select a release date",
+                              },
+                            ]}
                           >
                             <DatePicker showTime style={{ width: "100%" }} />
                           </Form.Item>
                         </Col>
+
                         <Col span={24} md={12}>
                           <Form.Item
                             label="DUE DATE (CDT)"
                             name="dueDate"
-                            rules={[{ required: true, message: "Please select a due date" }]}
+                            rules={[
+                              {
+                                required: true,
+                                message: "Please select a due date",
+                              },
+                            ]}
                           >
                             <DatePicker showTime style={{ width: "100%" }} />
                           </Form.Item>
                         </Col>
+
                         <Col span={24} md={12}>
                           <Form.Item
                             name="allowLateSubmissions"
@@ -328,6 +407,7 @@ export default ({
                             <Checkbox>Allow Late Submissions</Checkbox>
                           </Form.Item>
                         </Col>
+
                         <Col span={24} md={12}>
                           <Form.Item
                             label="LATE DUE DATE (CDT)"
@@ -339,7 +419,10 @@ export default ({
                                   if (!value || getFieldValue("dueDate") < value) {
                                     return Promise.resolve();
                                   }
-                                  return Promise.reject(new Error("Late due date must be after due date"));
+
+                                  return Promise.reject(
+                                    new Error("Late due date must be after due date")
+                                  );
                                 },
                               }),
                             ]}
@@ -347,36 +430,10 @@ export default ({
                             <DatePicker showTime style={{ width: "100%" }} />
                           </Form.Item>
                         </Col>
-                        {assignmentType === "1" ? (
-                          <>
-                            <Col span={24} md={12}>
-                              <Form.Item
-                                name="enforceTimeLimit"
-                                valuePropName="checked"
-                              >
-                                <Checkbox>Enforce time limit</Checkbox>
-                              </Form.Item>
-                            </Col>
-                            <Col span={24} md={12}>
-                              <Form.Item
-                                label="MAXIMUM TIME PERMITTED (MINUTES)"
-                                name="maximumTimePermitted"
-                              >
-                                <DatePicker
-                                  showTime
-                                  style={{ width: "100%" }}
-                                />
-                              </Form.Item>
-                            </Col>
-                          </>
-                        ) : null}
                       </Row>
                     </Form.Item>
 
-                    <Form.Item
-                      label="SUBMISSION TYPE"
-                      name="submissionType"
-                    >
+                    <Form.Item label="SUBMISSION TYPE" name="submissionType">
                       <Radio.Group>
                         <Space direction="vertical">
                           <Radio value={0}>Variable Length</Radio>
@@ -392,6 +449,7 @@ export default ({
                     >
                       <Checkbox>Enable Group Submission</Checkbox>
                     </Form.Item>
+
                     <Form.Item
                       label="LIMIT GROUP SIZE"
                       name="limitGroupSize"
@@ -403,50 +461,162 @@ export default ({
                       <Input />
                     </Form.Item>
 
-                    <Form.Item
-                      label="ENABLE AI FEEDBACK"
-                      name="ai_feedback_enabled"
-                      valuePropName="checked"
-                    >
-                      <Switch />
-                    </Form.Item>
+                    <Card title="AI Feedback Settings" style={{ marginBottom: 24 }}>
+                      <Form.Item
+                        label="Enable AI Feedback"
+                        name="ai_feedback_enabled"
+                        valuePropName="checked"
+                      >
+                        <Switch />
+                      </Form.Item>
 
-                    <Form.Item
-                      label="AI FEEDBACK PROMPT"
-                      name="ai_feedback_prompt"
-                      initialValue={"You are an AI used to provide constructive feedback to students on their coding assignments. Provide feedback on the following assignment regarding correctness, efficiency, code quality, documentation, error handling, style/formatting."}
-                      rules={[{ required: aiFeedbackEnabled, message: "Please enter a feedback prompt" }]}
-                    >
-                      <Input.TextArea
-                        placeholder="Enter the feedback prompt for AI"
-                        autoSize={{ minRows: 4, maxRows: 8 }}
-                        disabled={!aiFeedbackEnabled}
-                      />
-                    </Form.Item>
+                      {aiFeedbackEnabled && (
+                        <>
+                          <Alert
+                            type={
+                              courseAiInfo.has_openai_api_key ||
+                              courseAiInfo.has_gemini_api_key ||
+                              courseAiInfo.has_claude_api_key
+                                ? "success"
+                                : "warning"
+                            }
+                            showIcon
+                            style={{ marginBottom: 16 }}
+                            message="Current Course AI Default"
+                            description={
+                              courseAiInfo.default_ai_provider &&
+                              courseAiInfo.default_ai_model
+                                ? `Using ${courseAiInfo.default_ai_provider} / ${courseAiInfo.default_ai_model} by default.`
+                                : "Course default AI settings are incomplete. Configure them in Course AI Settings first."
+                            }
+                          />
 
-                    <Form.Item
-                      label="AI MODEL USED"
-                      name="ai_feedback_model"
-                      rules={[{ required: aiFeedbackEnabled, message: "Please select an AI model (e.g. gpt-5o)" }]}
-                    >
-                      <Input.TextArea
-                        placeholder="gpt-5o"
-                        autoSize={{ minRows: 1, maxRows: 1}}
-                        disabled={!aiFeedbackEnabled}
-                      />
-                    </Form.Item>
+                          <Form.Item
+                            label="Model Source"
+                            name="use_course_ai_default"
+                            initialValue={true}
+                          >
+                            <Radio.Group>
+                              <Space direction="vertical">
+                                <Radio value={true}>
+                                  Use course default
+                                  <Typography.Text
+                                    type="secondary"
+                                    style={{ marginLeft: 8 }}
+                                  >
+                                    {courseAiInfo.default_ai_provider || "No provider"} /{" "}
+                                    {courseAiInfo.default_ai_model || "No model"}
+                                  </Typography.Text>
+                                </Radio>
 
-                    <Form.Item
-                      label="MODEL TEMPERATURE"
-                      name="ai_feedback_temperature"
-                      initialValue={0.5}
-                      rules={[
-                        { required: aiFeedbackEnabled, message: "Please enter a temperature" },
-                        { pattern: /^0(\.\d+)?|1$/, message: "Enter a value between 0 and 1" },
-                      ]}
-                    >
-                      <Input placeholder="Enter temperature (0 to 1)" disabled={!aiFeedbackEnabled} />
-                    </Form.Item>
+                                <Radio value={false}>
+                                  Customize for this assignment only
+                                </Radio>
+                              </Space>
+                            </Radio.Group>
+                          </Form.Item>
+
+                          {useCourseAiDefault === false && (
+                            <Card size="small" title="Custom Assignment Model">
+                              <Form.Item
+                                label="Provider"
+                                name="ai_feedback_provider"
+                                rules={[
+                                  {
+                                    required: true,
+                                    message: "Please select an AI provider",
+                                  },
+                                ]}
+                              >
+                                <Select
+                                  options={[
+                                    { label: "ChatGPT", value: "openai" },
+                                    { label: "Gemini", value: "gemini" },
+                                    { label: "Claude", value: "claude" },
+                                  ]}
+                                  onChange={() => {
+                                    setAssignmentModels([]);
+                                    form.setFieldsValue({
+                                      ai_feedback_model: undefined,
+                                    });
+                                  }}
+                                />
+                              </Form.Item>
+
+                              <Form.Item
+                                label="Model"
+                                name="ai_feedback_model"
+                                rules={[
+                                  {
+                                    required: true,
+                                    message: "Please fetch and select an AI model",
+                                  },
+                                ]}
+                              >
+                                <Space.Compact style={{ width: "100%" }}>
+                                  <Button
+                                    onClick={handleFetchAssignmentModels}
+                                    loading={assignmentModelsLoading}
+                                    style={{ width: 180 }}
+                                  >
+                                    Fetch Models
+                                  </Button>
+
+                                  <Select
+                                    placeholder="Select a model"
+                                    style={{ width: "100%" }}
+                                    disabled={assignmentModels.length === 0}
+                                    options={assignmentModels.map((model) => ({
+                                      label: model,
+                                      value: model,
+                                    }))}
+                                  />
+                                </Space.Compact>
+                              </Form.Item>
+                            </Card>
+                          )}
+
+                          <Form.Item
+                            label="Feedback Style"
+                            name="ai_feedback_style"
+                            initialValue="balanced"
+                          >
+                            <Select
+                              options={[
+                                { label: "Hint-based", value: "hint-based" },
+                                { label: "Balanced", value: "balanced" },
+                                { label: "Detailed debugging", value: "detailed-debugging" },
+                              ]}
+                            />
+                          </Form.Item>
+
+                          <Form.Item
+                            label="AI Feedback Prompt"
+                            name="ai_feedback_prompt"
+                            initialValue=""
+                          >
+                            <Input.TextArea
+                              placeholder="Optional. Leave blank to use the default correctness-only feedback prompt."
+                              autoSize={{ minRows: 4, maxRows: 8 }}
+                            />
+                          </Form.Item>
+
+                          <Form.Item
+                            label="Model Temperature"
+                            name="ai_feedback_temperature"
+                            initialValue={0.5}
+                            rules={[
+                              {
+                                pattern: /^0(\.\d+)?|1$/,
+                                message: "Enter a value between 0 and 1",
+                              },
+                            ]}
+                          >
+                            <Input placeholder="0.5" />
+                          </Form.Item>
+                        </>
+                      )}
+                    </Card>
 
                     <Form.Item
                       label="CONFIGURE AUTOGRADER"
@@ -454,7 +624,9 @@ export default ({
                       valuePropName="checked"
                       initialValue={false}
                     >
-                      <Switch onChange={(checked) => setConfigureAutograderNow(checked)} />
+                      <Switch
+                        onChange={(checked) => setConfigureAutograderNow(checked)}
+                      />
                     </Form.Item>
 
                     <AutograderSection
@@ -464,8 +636,9 @@ export default ({
                       autograderFile={autograderFile}
                       setAutograderFile={setAutograderFile}
                       onTestClick={openTest}
-                      disabled={!configureAutograderNow} 
+                      disabled={!configureAutograderNow}
                     />
+
                     <Form.Item style={{ marginBottom: 0 }} />
                   </>
                 )}
@@ -483,6 +656,7 @@ export default ({
           </Content>
         </Layout>
       )}
+
       <TestAutograder
         open={modalOpen}
         onCancel={closeTest}

--- a/frontend/src/pages/instructor/assignments/CreateAssignment.js
+++ b/frontend/src/pages/instructor/assignments/CreateAssignment.js
@@ -36,33 +36,7 @@ import TestResultsDisplay from "../../result/TestResultsDisplay";
 import { uploadAssignmentAutograder } from "../../../services/submission";
 import { createAssignment, updateAssignment } from "../../../services/assignment";
 import { getCourseInfo, fetchAiModels } from "../../../services/course";
-const DEFAULT_AI_FEEDBACK_PROMPT = `You are giving short, student-facing feedback on a programming assignment.
-
-Focus only on correctness and debugging.
-
-Allowed feedback topics:
-- Incorrect logic
-- Missing required behavior
-- Failed test cases
-- Edge cases
-- Runtime errors
-- Incorrect input/output handling
-- Incorrect return values
-- Algorithm mistakes
-
-Do not comment on:
-- Style
-- Formatting
-- Naming
-- Indentation
-- Readability
-- Refactoring
-
-Rules:
-- Do not provide corrected code.
-- Do not give copy-paste fixes.
-- Do not reveal the final answer.
-- Give short hints that help the student investigate the bug.`;
+import { DEFAULT_AI_FEEDBACK_PROMPT } from "../../../constants/aiFeedback";
 const { Sider, Content } = Layout;
 
 export default ({
@@ -102,7 +76,7 @@ export default ({
           ai_feedback_provider: course.default_ai_provider || "openai",
           ai_feedback_model: course.default_ai_model || undefined,
           ai_feedback_style: course.default_feedback_style || "balanced",
-          ai_feedback_prompt: "",
+          ai_feedback_prompt: DEFAULT_AI_FEEDBACK_PROMPT,
           ai_feedback_temperature: course.default_ai_temperature ?? 0.5,
         });
       } catch (e) {
@@ -342,7 +316,7 @@ export default ({
                   autograder: { operation: "zip", timeout: "300" },
                   use_course_ai_default: true,
                   ai_feedback_style: "balanced",
-                  ai_feedback_prompt: "",
+                  ai_feedback_prompt: DEFAULT_AI_FEEDBACK_PROMPT,
                   ai_feedback_temperature: 0.5,
                 }}
                 onFinish={handleFinish}
@@ -520,7 +494,6 @@ export default ({
                           <Form.Item
                             label="Model Source"
                             name="use_course_ai_default"
-                            initialValue={true}
                           >
                             <Radio.Group>
                               <Space direction="vertical">
@@ -605,7 +578,6 @@ export default ({
                           <Form.Item
                             label="Feedback Style"
                             name="ai_feedback_style"
-                            initialValue="balanced"
                           >
                             <Select
                               options={[
@@ -619,10 +591,9 @@ export default ({
                           <Form.Item
                             label="AI Feedback Prompt"
                             name="ai_feedback_prompt"
-                            initialValue=""
                           >
                             <Input.TextArea
-                              placeholder="Optional. Leave blank to use the default correctness-only feedback prompt."
+                              placeholder="Default feedback prompt"
                               autoSize={{ minRows: 4, maxRows: 8 }}
                             />
                           </Form.Item>
@@ -630,7 +601,6 @@ export default ({
                           <Form.Item
                             label="Model Temperature"
                             name="ai_feedback_temperature"
-                            initialValue={0.5}
                             rules={[
                               {
                                 pattern: /^0(\.\d+)?|1$/,

--- a/frontend/src/pages/result/TestResultsDisplay.js
+++ b/frontend/src/pages/result/TestResultsDisplay.js
@@ -1,8 +1,7 @@
 import React, { useContext, useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { GlobalContext } from "../../App";
-import { Collapse, Button, Space } from "antd";
-import { Tooltip, Spin, Tag, Modal } from "antd";
+import { Alert, Collapse, Button, Tooltip, Spin, Tag, Modal } from "antd";
 import { useRef } from "react";
 
 import "antd/dist/antd.css";
@@ -12,7 +11,7 @@ const { Panel } = Collapse;
 
 //can also be displayed as a modal
 const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, score, totalPoints, assignmentId, data, aiFeedbackEnabled, isModal = false, submissionId: submissionIdFromProps, onCancel }) => {
-  const { userInfo, courseInfo } = useContext(GlobalContext);
+  const { userInfo } = useContext(GlobalContext);
   const params = useParams();
   const submissionId = submissionIdFromProps || params.submissionId; //const { assignmentId } = useParams();
   const navigate = useNavigate();
@@ -20,13 +19,12 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
   const [studentCode, setStudentCode] = useState("");
   const [studentFileName, setStudentFileName] = useState("");
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [StudScore, setStudScore] = useState(score);
 
   const [highlightedLines, setHighlightedLines] = useState([]);
   const [annotations, setAnnotations] = useState([]);
+  const [aiFeedback, setAiFeedback] = useState(null);
   const [loadingStatus, setLoadingStatus] = useState("null"); // 'loading', 'success', 'error', or null
-  const [submissionDetails, setSubmissionDetails] = useState("null");
 
   // used to store the line references for scrolling to
   const lineRefs = useRef({});
@@ -51,9 +49,9 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
       console.error("not available");
     }
     setIsLoading(false);
-  }, [submissionId, navigate, userInfo, courseInfo]);
+  }, [submissionId, navigate, userInfo, data]);
 
-  const getAiAnnotations = () => {
+  const getAiAnnotations = useCallback(() => {
     if (!aiFeedbackEnabled) {
       // setAiFeedbackEnabled(false);
       setLoadingStatus(null);
@@ -70,11 +68,15 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
           setLoadingStatus("error");
           return null;
         }
-      } else {
-        console.error("AI Feedback is not a string", data.ai_feedback);
-        setLoadingStatus("error");
-        return null;
       }
+
+      if (typeof data.ai_feedback === "object") {
+        return data.ai_feedback;
+      }
+
+      console.error("AI Feedback has an unsupported format", data.ai_feedback);
+      setLoadingStatus("error");
+      return null;
     } else {
       // ai_feedback is still being generated or fetched
       console.log("ai_feedback is still being generated or fetched");
@@ -82,33 +84,58 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
       setLoadingStatus("loading");
       return null;
     }
-  };
+  }, [aiFeedbackEnabled, data]);
 
-  const findAnnotations = (code) => {
+  const findAnnotations = useCallback((code) => {
+    if (!aiFeedbackEnabled) {
+      setAiFeedback(null);
+      setHighlightedLines([]);
+      setAnnotations([]);
+      setLoadingStatus(null);
+      return;
+    }
+
     setLoadingStatus("loading");
 
     const aiAnnotations = getAiAnnotations();
     if (!aiAnnotations) {
+      setAiFeedback(null);
       setLoadingStatus("loading");
       return;
     }
 
     if (aiAnnotations.error) {
       console.error("AI feedback error:", aiAnnotations.error);
+      setAiFeedback({
+        error: aiAnnotations.error,
+        insights: Array.isArray(aiAnnotations.insights) ? aiAnnotations.insights : [],
+        annotations: [],
+      });
       setLoadingStatus("error");
       return;
     }
 
-    console.log("AI feedback: ", aiAnnotations);
+    const feedbackInsights = Array.isArray(aiAnnotations.insights)
+      ? aiAnnotations.insights
+      : [];
+    const feedbackAnnotations = Array.isArray(aiAnnotations.annotations)
+      ? aiAnnotations.annotations
+      : [];
 
-    const { annotations } = aiAnnotations;
-    if (!Array.isArray(annotations)) {
-      console.error("Missing or invalid 'annotations' array in AI feedback.");
+    if (
+      !Array.isArray(aiAnnotations.insights) &&
+      !Array.isArray(aiAnnotations.annotations)
+    ) {
+      console.error("Missing or invalid AI feedback arrays.");
       setLoadingStatus("error");
       return;
     }
 
-    console.log("Ai annotations: ", annotations);
+    setAiFeedback({
+      ...aiAnnotations,
+      insights: feedbackInsights,
+      annotations: feedbackAnnotations,
+    });
 
     const lines = code.split("\n");
     const highlighted = [];
@@ -116,7 +143,11 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
 
     const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole match
 
-    annotations.forEach(({ pattern, comment }) => {
+    feedbackAnnotations.forEach(({ pattern, comment }) => {
+      if (!pattern || !comment) {
+        return;
+      }
+
       let regex;
       try {
         const safePattern = escapeRegExp(pattern.trim()); // Escape special characters
@@ -137,7 +168,7 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
     setHighlightedLines(highlighted);
     setAnnotations(newAnnotations);
     setLoadingStatus("success");
-  };
+  }, [aiFeedbackEnabled, getAiAnnotations]);
 
   useEffect(() => {
     if (data) {
@@ -145,9 +176,9 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
       // setAiFeedbackEnabled(true);
       findAnnotations(data.student_code_file || "");
     }
-  }, [data]);
+  }, [data, findAnnotations]);
 
-  const fetchSubmissionDetails = async () => {
+  const fetchSubmissionDetails = useCallback(async () => {
     try {
       const response = await fetch(`${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${submissionId}`);
       const data = await response.json();
@@ -155,11 +186,11 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
     } catch (error) {
       console.error("Failed to fetch updated submission details:", error);
     }
-  };
+  }, [submissionId]);
 
   useEffect(() => {
     fetchSubmissionDetails();
-  }, [submissionId]);
+  }, [fetchSubmissionDetails]);
 
   const displayCodeWithAnnotations = () => {
     const lines = studentCode.split("\n");
@@ -172,8 +203,8 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
             <Tooltip title="Fetching AI feedback...">{loadingStatus === "loading" && <Spin size="small" />}</Tooltip>
 
             {loadingStatus === "success" && (
-              <Tooltip title="AI feedback was successfully loaded and applied to matching code lines.">
-                <Tag color="green">AI Feedback Loaded</Tag>
+              <Tooltip title="AI feedback was successfully loaded. Summary feedback may appear even when no line annotations are returned.">
+                <Tag color="green">AI Feedback Ready</Tag>
               </Tooltip>
             )}
 
@@ -218,6 +249,119 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
     );
   };
 
+  const renderAiFeedbackSummary = () => {
+    if (!aiFeedbackEnabled) {
+      return null;
+    }
+
+    if (loadingStatus === "loading") {
+      return (
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginTop: 20 }}
+          message="AI feedback is generating"
+          description="Refresh this submission shortly to see feedback after the model finishes."
+        />
+      );
+    }
+
+    if (loadingStatus === "error") {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginTop: 20 }}
+          message="AI feedback unavailable"
+          description={
+            aiFeedback?.error ||
+            "The AI feedback response could not be loaded or parsed."
+          }
+        />
+      );
+    }
+
+    if (loadingStatus !== "success" || !aiFeedback) {
+      return null;
+    }
+
+    const insights = Array.isArray(aiFeedback.insights) ? aiFeedback.insights : [];
+    const hasLineAnnotations = annotations.length > 0;
+
+    return (
+      <div style={{ marginTop: 20 }}>
+        {insights.length > 0 && (
+          <Alert
+            type="success"
+            showIcon
+            message="AI Feedback Summary"
+            description={
+              <ul style={{ marginBottom: 0, paddingLeft: 20 }}>
+                {insights.map((insight, index) => (
+                  <li key={`${insight}-${index}`}>{insight}</li>
+                ))}
+              </ul>
+            }
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        {!hasLineAnnotations && (
+          <Alert
+            type="info"
+            showIcon
+            message="No line-by-line annotations"
+            description="AI feedback was generated successfully, but it did not identify a specific code line that needed a comment."
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        {hasLineAnnotations && (
+          <div>
+            <h3>Line Feedback</h3>
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+              {annotations.map((annotation, index) => (
+                <div
+                  key={index}
+                  onClick={() => {
+                    const lineEl = lineRefs.current[annotation.line];
+                    if (lineEl) {
+                      lineEl.scrollIntoView({ behavior: "smooth", block: "center" });
+                      lineEl.style.transition = "background-color 0.5s";
+                      lineEl.style.backgroundColor = "#fff7d6";
+                      setTimeout(() => {
+                        lineEl.style.backgroundColor = "#ffe6e6";
+                      }, 1500);
+                    }
+                  }}
+                  style={{
+                    cursor: "pointer",
+                    backgroundColor: "#fafafa",
+                    border: "1px solid #ddd",
+                    borderLeft: "5px solid #1890ff",
+                    padding: "10px",
+                    borderRadius: "4px",
+                  }}
+                >
+                  <div
+                    style={{
+                      fontWeight: "bold",
+                      color: "#333",
+                      marginBottom: "6px",
+                    }}
+                  >
+                    Line {annotation.line}
+                  </div>
+                  <div style={{ color: "#555" }}>{annotation.comment}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const downloadFile = useCallback(() => {
     const element = document.createElement("a");
     const file = new Blob([studentCode], { type: "text/plain" });
@@ -229,10 +373,6 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
 
   if (isLoading) {
     return <p>Loading...</p>;
-  }
-
-  if (error) {
-    return <p>Error loading data: {error.message}</p>;
   }
 
   if (!testResults || !Array.isArray(testResults.tests)) {
@@ -267,40 +407,7 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
       <Collapse accordion>
         <Panel header={studentFileName} key="1">
           {displayCodeWithAnnotations()}
-          {aiFeedbackEnabled && annotations.length > 0 && (
-            <div style={{ marginTop: "20px" }}>
-              <h3>🔍 Feedback Summary</h3>
-              <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
-                {annotations.map((annotation, index) => (
-                  <div
-                    key={index}
-                    onClick={() => {
-                      const lineEl = lineRefs.current[annotation.line];
-                      if (lineEl) {
-                        lineEl.scrollIntoView({ behavior: "smooth", block: "center" });
-                        lineEl.style.transition = "background-color 0.5s";
-                        lineEl.style.backgroundColor = "#fff7d6"; // highlight color
-                        setTimeout(() => {
-                          lineEl.style.backgroundColor = "#ffe6e6"; // revert
-                        }, 1500);
-                      }
-                    }}
-                    style={{
-                      cursor: "pointer",
-                      backgroundColor: "#fafafa",
-                      border: "1px solid #ddd",
-                      borderLeft: "5px solid #1890ff",
-                      padding: "10px",
-                      borderRadius: "4px",
-                    }}
-                  >
-                    <div style={{ fontWeight: "bold", color: "#333", marginBottom: "6px" }}>📍 Line {annotation.line}</div>
-                    <div style={{ color: "#555" }}>{annotation.comment}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          {renderAiFeedbackSummary()}
           {/* <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>{studentCode}</pre> */}
           <Button onClick={downloadFile} type="primary" style={{ marginTop: "10px" }}>
             Download
@@ -324,10 +431,6 @@ const TestResultsDisplay = ({ viewMode, studentId, assignmentName, studentName, 
 
   if (isLoading) {
     return <p>Loading...</p>;
-  }
-
-  if (error) {
-    return <p>Error loading data: {error.message}</p>;
   }
 
   if (!testResults || !Array.isArray(testResults.tests)) {

--- a/frontend/src/services/course.js
+++ b/frontend/src/services/course.js
@@ -55,3 +55,19 @@ export async function updateRole(params) {
 export async function storeApiKey(params) {
   return service("store_api_key", params, "put");
 }
+
+export async function updateAiSettings(params) {
+  return service("update_ai_settings", params, "put");
+}
+
+export async function fetchAiModels(params) {
+  return service("fetch_ai_models", params, "post");
+}
+
+export async function testAiApiKey(params) {
+  return service("test_ai_api_key", params, "post");
+}
+
+export async function testAiModel(params) {
+  return service("test_ai_model", params, "post");
+}

--- a/frontend/src/test/unit/pages/instructor/assignments/CreateAssignment.test.jsx
+++ b/frontend/src/test/unit/pages/instructor/assignments/CreateAssignment.test.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Form } from "antd";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreateAssignment from "../../../../../pages/instructor/assignments/CreateAssignment";
+import { getCourseInfo } from "../../../../../services/course";
+
+jest.mock("../../../../../services/course", () => ({
+  getCourseInfo: jest.fn(),
+  fetchAiModels: jest.fn(),
+}));
+
+jest.mock("../../../../../services/assignment", () => ({
+  createAssignment: jest.fn(),
+  updateAssignment: jest.fn(),
+}));
+
+jest.mock("../../../../../services/submission", () => ({
+  uploadAssignmentAutograder: jest.fn(),
+}));
+
+jest.mock("../../../../../pages/configureAutograder/AutograderSection", () => () => (
+  <div data-testid="autograder-section" />
+));
+
+jest.mock("../../../../../pages/configureAutograder/TestAutograder", () => () => (
+  <div data-testid="test-autograder" />
+));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({ courseId: "course-1" }),
+}));
+
+function CreateAssignmentHarness() {
+  const [form] = Form.useForm();
+
+  return (
+    <CreateAssignment
+      currentStep={1}
+      updateCurrentStep={jest.fn()}
+      toggleIsCreate={jest.fn()}
+      nameValidationStatus=""
+      form={form}
+    />
+  );
+}
+
+describe("CreateAssignment AI prompt defaults", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    getCourseInfo.mockResolvedValue({
+      data: [
+        {
+          default_ai_provider: "openai",
+          default_ai_model: "gpt-4o-mini",
+          default_feedback_style: "balanced",
+          default_ai_temperature: 0.5,
+          has_openai_api_key: true,
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the default AI feedback prompt immediately when AI feedback is enabled", async () => {
+    const user = userEvent.setup();
+
+    render(<CreateAssignmentHarness />);
+
+    await waitFor(() => expect(getCourseInfo).toHaveBeenCalled());
+
+    await user.click(screen.getAllByRole("switch")[0]);
+
+    const promptInput = await screen.findByLabelText("AI Feedback Prompt");
+
+    expect(promptInput.value).toEqual(
+      expect.stringContaining("Always provide useful feedback")
+    );
+    expect(promptInput.value).toEqual(
+      expect.stringContaining("Improvement Suggestions")
+    );
+  });
+});

--- a/frontend/src/test/unit/pages/result/TestResultsDisplay.test.jsx
+++ b/frontend/src/test/unit/pages/result/TestResultsDisplay.test.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TestResultsDisplay from "../../../../pages/result/TestResultsDisplay";
+import { GlobalContext } from "../../../../App";
+
+jest.mock("../../../../pages/result/StudentInfoPanel", () => () => (
+  <div data-testid="student-info-panel" />
+));
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ submissionId: "submission-1" }),
+}));
+
+describe("TestResultsDisplay AI feedback", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ score: 10 }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows AI insights and success state when there are no line annotations", async () => {
+    const user = userEvent.setup();
+    const data = {
+      score: 10,
+      results: { tests: [] },
+      student_code_file: "def add(a, b):\n    return a + b\n",
+      file_name: "student.py",
+      ai_feedback: JSON.stringify({
+        insights: [
+          "Overall Summary: The submission passes the available tests.",
+          "Improvement Suggestion: Consider edge cases around invalid input.",
+        ],
+        annotations: [],
+      }),
+    };
+
+    render(
+      <GlobalContext.Provider value={{ userInfo: { id: "user-1" }, courseInfo: {} }}>
+        <TestResultsDisplay
+          viewMode="Code"
+          assignmentName="Calculator"
+          studentName="Ada Lovelace"
+          score={10}
+          totalPoints={10}
+          data={data}
+          aiFeedbackEnabled
+        />
+      </GlobalContext.Provider>
+    );
+
+    await user.click(await screen.findByText("student.py"));
+
+    expect(await screen.findByText("AI Feedback Summary")).toBeInTheDocument();
+    expect(
+      screen.getByText("Overall Summary: The submission passes the available tests.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Improvement Suggestion: Consider edge cases around invalid input.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("AI Feedback Ready")).toBeInTheDocument();
+    expect(screen.getByText("No line-by-line annotations")).toBeInTheDocument();
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
Summary
solve issue #310 #311 
This PR updates the AI feedback settings workflow for both course-level and assignment-level configuration.

Main changes:

- Added support for multiple AI providers:  OpenAI / ChatGPT,  Google Gemini,  Anthropic Claude
- Updated course-level AI settings to support provider-specific API keys and default model configuration.
- Added API key testing and selected model testing.
- Updated assignment-level AI feedback settings so assignments can either:
- Use course default AI settings, or Customize provider/model for that assignment only.
- Added default correctness-focused AI feedback prompt.
- Updated AI feedback generation to focus on correctness, debugging, failed tests, edge cases, and runtime behavior.
- Added model filtering logic for known unsupported or special-purpose models.
- Added documentation for how to use and test AI Settings.

Notes!!!!
The API key test and selected model test are intentionally separate.
A provider API key may be valid, but a selected model may still fail because some models are too advanced, deprecated, special-purpose, or require a different request format. Very normal API chaos, naturally.

Testing
OpenAI, Gemini, and Claude can all connect through the AI Settings page.
Users should click Fetch Models before choosing a model.
Users should click Test Selected Model before saving or using a model.
Some provider-returned models may not be usable for our AI feedback workflow.
If a model test fails, choose another available model and test again.

TEST NOTE:
docker compose down
docker compose up
Leave this terminal open so backend logs are visible.
If the database was already migrated before, you may not need to reset volumes. But if you see missing column/table errors, run migration again.
!!Run database migration 
Open a new terminal:
cd ~/Desktop/.../codeAssist
docker compose exec backend sh
flask db upgrade
python3 init_db.py
exit
Backend:
PYTHONPATH=. python -m pytest
Frontend:
npm test -- --watchAll=false

https://github.com/user-attachments/assets/803fc364-5883-4c22-a2c8-f3dae66ce287

