### PR TITLE
Fix resubmit runtime issue (Fixes Issue #304)

### DIFF
--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -496,8 +496,14 @@ def get_active_submission():
 
     if not assignment or not student:
       raise BadRequestError("not sufficient details")
+
+    try:
+        student_uuid = uuid.UUID(str(student))
+        assignment_uuid = uuid.UUID(str(assignment))
+    except (ValueError, TypeError):
+        raise BadRequestError("Invalid student_id or assignment_id")
     
-    submission = db.session.query(Submission).filter_by(assignment_id=assignment, student_id=student, active=True).first()
+    submission = db.session.query(Submission).filter_by(assignment_id=assignment_uuid, student_id=student_uuid, active=True).first()
 
     if not submission:
         raise NotFoundError("No such submission found")

--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -496,14 +496,8 @@ def get_active_submission():
 
     if not assignment or not student:
       raise BadRequestError("not sufficient details")
-
-    try:
-        student_uuid = uuid.UUID(str(student))
-        assignment_uuid = uuid.UUID(str(assignment))
-    except (ValueError, TypeError):
-        raise BadRequestError("Invalid student_id or assignment_id")
     
-    submission = db.session.query(Submission).filter_by(assignment_id=assignment_uuid, student_id=student_uuid, active=True).first()
+    submission = db.session.query(Submission).filter_by(assignment_id=assignment, student_id=student, active=True).first()
 
     if not submission:
         raise NotFoundError("No such submission found")

--- a/frontend/src/components/UploadModal.js
+++ b/frontend/src/components/UploadModal.js
@@ -30,20 +30,38 @@ export default function UploadModal({
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
   const [activeSubmission, setActiveSubmission] = useState();
   const [hasRequest, setHasRequest] = useState(false);
+  const [fileList, setFileList] = useState([]);
 
   useEffect(() => {
-    if (open) {
+    if (!open) {
+      setFileList([]);
+      setFile(null);
+      return;
+    }
+
+    if (open && userInfo?.id && assignmentID) {
       getActive();
     }
-  }, [open, userInfo.id, assignmentID]);
+  }, [open, userInfo?.id, assignmentID]);
 
   const getActive = async () => {
     try {
       const submissionResponse = await fetch(`${process.env.REACT_APP_API_URL}/get_active_submission?student_id=${userInfo.id}&assignment_id=${assignmentID}`);
+      if (!submissionResponse.ok) {
+        setActiveSubmission(null);
+        setHasRequest(false);
+        return;
+      }
+
       const submissionData = await submissionResponse.json();
-      console.log(submissionData)
-      console.log(submissionData.id)
-      setActiveSubmission(submissionData.id)
+      const submissionId = submissionData?.id ?? null;
+      setActiveSubmission(submissionId);
+
+      if (!submissionId) {
+        setHasRequest(false);
+        return;
+      }
+
       const req = await fetch(
         `${process.env.REACT_APP_API_URL}/check_regrade_request`,
         {
@@ -52,25 +70,31 @@ export default function UploadModal({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            submission_id: submissionData.id,
+            submission_id: submissionId,
           }),
         }
       );
       const reqData = await req.json();
-      console.log("this is the response data:", reqData.has_request)
-      setHasRequest(reqData.has_request)
+      setHasRequest(Boolean(reqData?.has_request));
     } catch(error){
+      setActiveSubmission(null);
+      setHasRequest(false);
       message.error("Failed")
     }
   }
 
 
   const handleFileChange = (info) => {
+    const nextFileList = Array.isArray(info.fileList) ? info.fileList.slice(-1) : [];
+    setFileList(nextFileList);
+
     if (info.file.status === 'done') {
-      setFile(info.file.originFileObj);
+      setFile(info.file.originFileObj || info.file);
       message.success(`${info.file.name} file uploaded successfully.`);
     } else if (info.file.status === 'error') {
       message.error(`${info.file.name} file upload failed.`);
+    } else if (info.file.status === 'removed') {
+      setFile(null);
     }
   };
 
@@ -93,10 +117,9 @@ export default function UploadModal({
 
 
   const navigateToResults = (submissionID) => {
-    onCancel()
-    //use the returned submission id to navigate to its reults
+    onCancel?.();
     navigate(`/assignmentResult/${submissionID}`);
-    extra()
+    extra?.();
   };
 
   const handleConfirm = async () => {
@@ -137,6 +160,8 @@ export default function UploadModal({
       setLoading(true); // Show loading overlay
       const response = await uploadSubmission(formData)
       const responseData = response.data;
+      setFileList([]);
+      setFile(null);
 
       // Proceed to results page after successful upload
       navigateToResults(responseData.submissionID);
@@ -161,13 +186,19 @@ export default function UploadModal({
     <LoadingOverlay loading={loading} /> 
     <Modal title="Submit Assignment" open={open} onCancel={onCancel} footer={null}>
       <Form layout="vertical">
-        <Form.Item name="upload" valuePropName="fileList">
+        <Form.Item
+          name="upload"
+          valuePropName="fileList"
+          getValueFromEvent={(info) => Array.isArray(info.fileList) ? info.fileList : []}
+        >
           <Upload.Dragger
             name="file"
             multiple={false}
+            fileList={fileList}
             onChange={handleFileChange}
             beforeUpload={file => {
-              setFile(file); // Set file on beforeUpload instead of upload itself
+              setFile(file);
+              setFileList([{ uid: file.uid || `${Date.now()}`, name: file.name, status: 'done', originFileObj: file }]);
               return false; // Prevent default upload
             }}
             onDrop={e => console.log('Dropped files', e.dataTransfer.files)}

--- a/frontend/src/pages/assignments/assignment_modal.js
+++ b/frontend/src/pages/assignments/assignment_modal.js
@@ -8,16 +8,22 @@ import LoadingOverlay from "../../components/LoadingOverlay";
 
 export default function AssignmentModal({ open, onCancel, assignmentID, assignmentTitle }) {
   const [file, setFile] = useState(null);
+  const [fileList, setFileList] = useState([]);
   const { userInfo } = useContext(GlobalContext);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleFileChange = (info) => {
+    const nextFileList = Array.isArray(info.fileList) ? info.fileList.slice(-1) : [];
+    setFileList(nextFileList);
+
     if (info.file.status === 'done') {
-      setFile(info.file.originFileObj);
+      setFile(info.file.originFileObj || info.file);
       message.success(`${info.file.name} file uploaded successfully.`);
     } else if (info.file.status === 'error') {
       message.error(`${info.file.name} file upload failed.`);
+    } else if (info.file.status === 'removed') {
+      setFile(null);
     }
   };
 
@@ -69,9 +75,11 @@ export default function AssignmentModal({ open, onCancel, assignmentID, assignme
           <Upload.Dragger
             name="file"
             multiple={false}
+            fileList={fileList}
             onChange={handleFileChange}
             beforeUpload={file => {
-              setFile(file); // Set file on beforeUpload instead of upload itself
+              setFile(file);
+              setFileList([{ uid: file.uid || `${Date.now()}`, name: file.name, status: 'done', originFileObj: file }]);
               return false; // Prevent default upload
             }}
             onDrop={e => console.log('Dropped files', e.dataTransfer.files)}

--- a/frontend/src/pages/result/index.js
+++ b/frontend/src/pages/result/index.js
@@ -173,11 +173,18 @@ export default function AssignmentResult() {
   const toggleModal = useCallback(
     (type) => {
       if (type === "upload") {
-        //if the due date hasnt passed open the model or else send an error message saying dude date has passes
         const now = moment();
-        if (!now.isAfter(dueDate)) {
+        const due = dueDate ? moment(dueDate) : null;
+        const late = lateDueDate ? moment(lateDueDate) : null;
+
+        if (!due && !late) {
           setUploadModalOpen((prev) => !prev);
-        } else if (lateAllowed && !now.isAfter(lateDueDate)) {
+          return;
+        }
+
+        if (due && !now.isAfter(due)) {
+          setUploadModalOpen((prev) => !prev);
+        } else if (late && lateAllowed && !now.isAfter(late)) {
           setUploadModalOpen((prev) => !prev);
         } else {
           message.error("Due Date Has Passed");
@@ -185,7 +192,7 @@ export default function AssignmentResult() {
       } else if (type === "history") setHistoryModalOpen((prev) => !prev);
       else if (type === "formatting") setFormattingOpen((prev) => !prev);
     },
-    [dueDate]
+    [dueDate, lateDueDate, lateAllowed]
   );
 
   const handleRadioChange = useCallback((e) => {

--- a/frontend/src/pages/result/submissionHistoryModal.js
+++ b/frontend/src/pages/result/submissionHistoryModal.js
@@ -33,11 +33,28 @@ export default function SubmissionHistoryModal({ open, onCancel, studentId, assi
   };
   const getActive = async () => {
     try {
+      if (!studentId || !assignmentId) {
+        setActiveSubmission(null);
+        setHasRequest(false);
+        return;
+      }
+
       const submissionResponse = await fetch(`${process.env.REACT_APP_API_URL}/get_active_submission?student_id=${studentId}&assignment_id=${assignmentId}`);
+      if (!submissionResponse.ok) {
+        setActiveSubmission(null);
+        setHasRequest(false);
+        return;
+      }
+
       const submissionData = await submissionResponse.json();
-      console.log(submissionData)
-      console.log(submissionData.id)
-      setActiveSubmission(submissionData.id)
+      const submissionId = submissionData?.id ?? null;
+      setActiveSubmission(submissionId);
+
+      if (!submissionId) {
+        setHasRequest(false);
+        return;
+      }
+
       const req = await fetch(
         `${process.env.REACT_APP_API_URL}/check_regrade_request`,
         {
@@ -46,17 +63,15 @@ export default function SubmissionHistoryModal({ open, onCancel, studentId, assi
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            submission_id: submissionData.id,
+            submission_id: submissionId,
           }),
         }
       );
-      // const req = await axios.post(`${process.env.REACT_APP_API_URL}/check_regrade_request`, {
-      //   submission_id: submissionData.id,
-      // });
       const reqData = await req.json();
-      console.log("this is the response data:", reqData.has_request)
-      setHasRequest(reqData.has_request)
+      setHasRequest(Boolean(reqData?.has_request));
     } catch(error){
+      setActiveSubmission(null);
+      setHasRequest(false);
       message.error("Failed")
     }
   }
@@ -151,15 +166,17 @@ export default function SubmissionHistoryModal({ open, onCancel, studentId, assi
       title: 'Active',
       key: 'active',
       //new redner to only render the checkmark when the submission is actually active accoridng to the database
-      render: (text, record) => record.active? "✓": <Button onClick={(e) => handleSetDefaultSubmission(record.id, e)}>Activate</Button>
+      render: (text, record) => record.active ? "✓" : <Button onClick={(e) => handleSetDefaultSubmission(record.id, e)}>Activate</Button>
       //render: (text, record, index) => submissions.length && index === 0 ? "✓" : "" 
     },
   ];
 
+  const currentSubmissionId = currSubData?.id ?? null;
+
   const onRowClick = (record) => {
-    if (record.id !== currSubData.id) {
+    if (record?.id && currentSubmissionId && record.id !== currentSubmissionId) {
       navigate(`/assignmentResult/${record.id}`);
-      extra();
+      extra?.();
     }
   }; 
 
@@ -178,7 +195,7 @@ export default function SubmissionHistoryModal({ open, onCancel, studentId, assi
         pagination={false}
         onRow={(record) => ({
           onClick: () => onRowClick(record),
-          style: { cursor: 'pointer', backgroundColor: record.id === currSubData.id ? '#e6f7ff' : '' },
+          style: { cursor: 'pointer', backgroundColor: record.id === currentSubmissionId ? '#e6f7ff' : '' },
         })}
       />
        <Modal

--- a/frontend/src/test/unit/UploadModal.test.jsx
+++ b/frontend/src/test/unit/UploadModal.test.jsx
@@ -32,6 +32,7 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
 
 describe('<UploadModal />', () => {
   const fakeNavigate = jest.fn();
+  const fetchMock = jest.fn();
   useNavigate.mockReturnValue(fakeNavigate);
 
   const defaultProps = {
@@ -57,6 +58,7 @@ describe('<UploadModal />', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    global.fetch = fetchMock;
   });
 
   it('shows error message when submitting without a file', async () => {
@@ -68,5 +70,18 @@ describe('<UploadModal />', () => {
     });
   });
 
-  // Additional tests (file upload, successful submission) can be added here.
+  it('handles a missing active submission without crashing', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: 'No such submission found' }),
+    });
+
+    renderWithContext(<UploadModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/test/unit/pages/result/SubmissionHistoryModal.test.jsx
+++ b/frontend/src/test/unit/pages/result/SubmissionHistoryModal.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SubmissionHistoryModal from '../../../../pages/result/submissionHistoryModal';
+import { message } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('axios');
+
+jest.spyOn(message, 'error').mockImplementation(() => {});
+
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}
+
+describe('<SubmissionHistoryModal />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNavigate.mockReturnValue(jest.fn());
+    axios.get.mockResolvedValue({ data: [] });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'No active submission' }),
+    });
+  });
+
+  it('renders without crashing when no current submission is provided', async () => {
+    render(
+      <SubmissionHistoryModal
+        open={true}
+        onCancel={jest.fn()}
+        studentId={1}
+        assignmentId={2}
+        studentName="Student"
+        extra={jest.fn()}
+        currSubData={undefined}
+      />
+    );
+
+    expect(await screen.findByText('Submission History')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Upload and submission flows were unstable due to incorrect file state handling. This caused UI crashes and inconsistent behavior.

Frontend
- Fixed Ant Design Upload by using controlled `fileList`
- Ensured file state resets on:
  - modal close
  - file removal
  - successful upload
- Fixed submission history modal crash cases