### PR TITLE
Add help page and navigation (Fixes #295)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,7 @@ import GradeSubmissions from "./pages/gradeSubmissions";
 import Extensions from "./pages/extensions";
 import AssignmentSettings from "./pages/assignmentSettings";
 import EditAccount from "./pages/editAccount";
+import HelpPage from "./pages/help";
 import RegradeRequests from './components/RegradeRequests';
 import AdminDashboard from "./pages/admin/dashboard";
 import AdminSidebar from "./components/layout/AdminSidebar";
@@ -220,6 +221,7 @@ function App() {
                 path = '/editAccount/:userId'
                 element={<EditAccount />} 
               />
+              <Route path="/help" element={<HelpPage />} />
               <Route path="/regradeRequests" element={<RegradeRequests />} />
               <Route path='/admin/students/manage/:studentId' element={<AdminStudentManage />} />
               <Route path='/admin/students/add' element={<AdminStudentAdd />} />

--- a/frontend/src/components/layout/accountPopoverContent.js
+++ b/frontend/src/components/layout/accountPopoverContent.js
@@ -21,8 +21,10 @@ export default function AccountPopoverContent() {
       }}
     >
       <div>
-        <QuestionCircleFilled />
-        <span> Help</span>
+        <Link to="/help">
+          <QuestionCircleFilled />
+          <span> Help</span>
+        </Link>
       </div>
       {!isAdmin && (
         <>

--- a/frontend/src/pages/help/index.js
+++ b/frontend/src/pages/help/index.js
@@ -1,0 +1,19 @@
+import { Card, PageHeader, Typography } from "antd";
+
+export default function HelpPage() {
+  return (
+    <div style={{ padding: 24 }}>
+      <PageHeader title="Help" />
+      <Card>
+        <Typography.Title level={4}>Getting started</Typography.Title>
+        <Typography.Paragraph>
+          Use the dashboard to view assignments, review submissions, and manage course settings.
+        </Typography.Paragraph>
+        <Typography.Title level={5}>Need more help?</Typography.Title>
+        <Typography.Paragraph>
+          Contact your course administrator or instructor for additional support.
+        </Typography.Paragraph>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Help navigation from the account menu was broken or missing.

- Added basic Help page and `/help` route
- Connected Help option in account menu to route