### PR TITLE
Fix enrollment counts display

### DIFF
--- a/frontend/src/pages/instructor/enrollment/index.js
+++ b/frontend/src/pages/instructor/enrollment/index.js
@@ -147,7 +147,16 @@ export default () => {
   useEffect(() => {
     getEnrollment();
   }, [getEnrollment, courseId]);
-
+  // count the number of students, instructors, and TAs for the course
+  const studentCount = originalEnrollment.filter(
+    (e) => e.role?.toLowerCase() === "student"
+  ).length;
+  const instructorCount = originalEnrollment.filter(
+    (e) => e.role?.toLowerCase() === "instructor"
+  ).length;
+  const taCount = originalEnrollment.filter(
+    (e) => e.role?.toLowerCase() === "ta"
+  ).length;
   return (
     <>
       <PageHeader
@@ -240,9 +249,9 @@ export default () => {
         }}
       >
         <Space size="large">
-          <Typography.Title level={5}>50 students</Typography.Title>
-          <Typography.Title level={5}>2 instructors</Typography.Title>
-          <Typography.Title level={5}>2 TAs</Typography.Title>
+          <Typography.Title level={5}> {studentCount} students</Typography.Title>
+          <Typography.Title level={5}> {instructorCount} instructors</Typography.Title>
+          <Typography.Title level={5}> {taCount} TAs</Typography.Title>
         </Space>
         <div
           style={{


### PR DESCRIPTION
Solve issue #315 
The enrollment count displayed at the bottom of the enrollment section is incorrect, and it was hardcode inside frontend/src/pages/instructor/enrollment/index.js

Frontend
- Replaced hardcoded enrollment statistics with dynamically calculated counts based on course enrollment data
- Added automatic counting for Students, Instructors, and TAs from the enrollment API response
- Updated the footer to display accurate enrollment totals for each course

Testing
- Verified counts update correctly when viewing courses with different enrollment sizes
- Confirmed displayed totals match the enrollment data returned by the backend API

Before 
<img width="1707" height="1031" alt="Screenshot 2026-06-19 at 3 53 25 PM" src="https://github.com/user-attachments/assets/ef39b75d-46a9-4484-82c1-243098e7e611" />

After 
<img width="1708" height="1033" alt="Screenshot 2026-06-19 at 11 22 10 PM" src="https://github.com/user-attachments/assets/44a5d49c-2040-45bc-9fab-421204048b0b" />
