### PR TITLE
Fix CSV student enrollment

### DIFF
--- a/backend/routes/course.py
+++ b/backend/routes/course.py
@@ -4,6 +4,7 @@ import csv
 from flask import Blueprint, request, jsonify
 from flask_cors import cross_origin
 from werkzeug.utils import secure_filename
+from sqlalchemy.exc import IntegrityError
 from api import db
 from api.models import (
     Assignment,
@@ -332,17 +333,21 @@ def create_enrollment_bulk(data):
     for student_id in students:
         try:
             enrollment = Enrollment(
-                student_id=student_id, 
-                course_id=course_id, 
+                student_id=student_id,
+                course_id=course_id,
                 role=role
             )
             db.session.add(enrollment)
             db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            failed_enrollments.append((student_id, "Already enrolled"))
         except Exception:
-            failed_enrollments.append(student_id)
+            db.session.rollback()
+            failed_enrollments.append((student_id, "Enrollment failed"))
     
     return {
-        "failed_enrollments" : failed_enrollments
+        "failed_enrollments": [{"id": sid, "reason": reason} for sid, reason in failed_enrollments]
     }
 
 def allowed_file(filename):
@@ -379,21 +384,63 @@ def create_enrollment_csv():
     if not course_id:
         raise BadRequestError("Missing course_id")
     
+    pre_failed = []
+
     try:
-        with open(file_path, newline='')  as csvfile:
+        with open(file_path, newline='') as csvfile:
             csv_reader = csv.reader(csvfile, delimiter=',')
-            for row in csv_reader:
-                student_ids.append(row[0])
-    except Exception as e:
+            rows = list(csv_reader)
+    except Exception:
         raise InternalProcessingError("Failed to process file")
     finally:
         if os.path.exists(file_path):
             os.remove(file_path)
 
+    if not rows:
+        raise BadRequestError("CSV file is empty")
+
+    header = [col.strip().lower() for col in rows[0]]
+    email_aliases = {"email", "email address"}
+    matched = [col for col in header if col in email_aliases]
+    if not matched:
+        raise BadRequestError("CSV must contain an 'Email' or 'Email Address' column header")
+
+    email_col = header.index(matched[0])
+    role_col = header.index("role") if "role" in header else None
+
+    id_to_email = {}
+
+    for row in rows[1:]:
+        if not row or len(row) <= email_col:
+            continue
+        email = row[email_col].strip()
+        if not email:
+            continue
+        user = User.query.filter_by(email_address=email).first()
+        if not user:
+            pre_failed.append({"email": email, "reason": "User not found"})
+            continue
+        uid = str(user.id)
+        id_to_email[uid] = email
+        student_ids.append(uid)
+
+    role = "student"
+    if role_col and len(rows) > 1 and len(rows[1]) > role_col:
+        role = rows[1][role_col].strip().lower() or "student"
+
+    if not student_ids:
+        return jsonify({"failed_enrollments": pre_failed}), 200
+
     response = create_enrollment_bulk({
         "course_id": course_id,
-        "student_ids": student_ids
-        })
+        "student_ids": student_ids,
+        "role": role
+    })
+
+    response["failed_enrollments"] = [
+        {"email": id_to_email.get(f["id"], f["id"]), "reason": f["reason"]}
+        for f in response["failed_enrollments"]
+    ] + pre_failed
 
     return jsonify(response), 200
 

--- a/backend/test/unit/test_course.py
+++ b/backend/test/unit/test_course.py
@@ -323,11 +323,17 @@ def test_update_role_not_found(client, mocker):
 import io
 
 def test_create_enrollment_csv_success(client, mocker):
-    # create a file like object to simulate the uploaded file
-    file_content = "student-1\nstudent-2"
+    file_content = "Email\nstudent1@test.com\nstudent2@test.com"
     mock_file = (io.BytesIO(file_content.encode()), "students.csv")
 
-    # Mock dependencies
+    mock_user_1 = mocker.Mock()
+    mock_user_1.id = "uuid-1"
+    mock_user_2 = mocker.Mock()
+    mock_user_2.id = "uuid-2"
+
+    mock_query = mocker.patch("routes.course.User.query")
+    mock_query.filter_by.return_value.first.side_effect = [mock_user_1, mock_user_2]
+
     mocker.patch("routes.course.allowed_file", return_value=True)
     mocker.patch("routes.course.os.path.exists", return_value=False)
     mocker.patch("routes.course.os.makedirs")
@@ -344,8 +350,12 @@ def test_create_enrollment_csv_success(client, mocker):
 
     assert response.status_code == 200
     assert response.json["failed_enrollments"] == []
-    mock_open.assert_any_call(mocker.ANY, newline="")  
-    mock_create_bulk.assert_called_once_with({"course_id": "course-123", "student_ids": ["student-1", "student-2"]})
+    mock_open.assert_any_call(mocker.ANY, newline="")
+    mock_create_bulk.assert_called_once_with({
+        "course_id": "course-123",
+        "student_ids": ["uuid-1", "uuid-2"],
+        "role": "student"
+    })
 
 
 def test_create_enrollment_csv_missing_file(client, mocker):
@@ -460,6 +470,7 @@ def test_create_enrollment_bulk_with_failures(mocker):
 
     mocker.patch("routes.course.db.session.add", side_effect=raise_error)
     mocker.patch("routes.course.db.session.commit", side_effect=raise_error)
+    mocker.patch("routes.course.db.session.rollback")
 
     data = {
         "course_id": "course-1",
@@ -467,7 +478,8 @@ def test_create_enrollment_bulk_with_failures(mocker):
     }
 
     result = create_enrollment_bulk(data)
-    assert set(result["failed_enrollments"]) == {"a", "b"}  # Compare as sets to ignore order
+    failed_ids = {f["id"] for f in result["failed_enrollments"]}
+    assert failed_ids == {"a", "b"}
 
 def test_create_course_get_not_allowed(client):
     response = client.get("/create_course")

--- a/frontend/src/pages/instructor/enrollment/AddCSVModal.js
+++ b/frontend/src/pages/instructor/enrollment/AddCSVModal.js
@@ -86,12 +86,12 @@ const AddCSVModal = ({ open, toggleAddCSVModalOpen, finishCSVForm , getEnrollmen
       <Form layout="vertical" onFinish={handleFinish}>
         <p style={{ marginBottom: 8, color: "#595959" }}>
           Upload a CSV with a header row. The <b>Email</b> column is required.
-          Optionally include <b>Name</b>, <b>EID</b>, and <b>Role</b> columns.
+          Optionally include <b>Name</b>, <b>SID</b>, and <b>Role</b> columns.
         </p>
         <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12, fontFamily: "monospace", marginBottom: 16 }}>
           <thead>
             <tr style={{ background: "#e8e8e8" }}>
-              {["Name", "Email", "EID", "Role"].map(col => (
+              {["Name", "Email", "SID", "Role"].map(col => (
                 <th key={col} style={{ border: "1px solid #d9d9d9", padding: "4px 8px", textAlign: "left", fontWeight: 600 }}>
                   {col}
                 </th>

--- a/frontend/src/pages/instructor/enrollment/AddCSVModal.js
+++ b/frontend/src/pages/instructor/enrollment/AddCSVModal.js
@@ -5,7 +5,8 @@ import LoadingOverlay from "../../../components/LoadingOverlay";
 
 const AddCSVModal = ({ open, toggleAddCSVModalOpen, finishCSVForm , getEnrollment}) => {
   const [fileList, setFileList] = useState([]);
-  const [loading, setLoading]  = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [failedList, setFailedList] = useState([]);
 
   const maxMB = 101 // limit in MB
   const maxSize = maxMB * 1024 * 1024; // limit in bytes
@@ -54,22 +55,28 @@ const AddCSVModal = ({ open, toggleAddCSVModalOpen, finishCSVForm , getEnrollmen
     setLoading(true);
 
     try {
-      await finishCSVForm(formData);
-      message.success("Enrollments processed.");
-      toggleAddCSVModalOpen();
-      getEnrollment();
+      const result = await finishCSVForm(formData);
+      const failed = result?.failed_enrollments ?? [];
+      if (failed.length === 0) {
+        message.success("All students enrolled successfully.");
+        toggleAddCSVModalOpen();
+        setFileList([]);
+      } else {
+        setFailedList(failed);
+        getEnrollment();
+      }
     } catch(error) {
       console.error("Error processing enrollments:", error);
       message.error("An error occurred while processing enrollments.");
     } finally {
       setLoading(false);
     }
-    setFileList([]);
   }
 
   const handleCancel = () => {
     toggleAddCSVModalOpen();
     setFileList([]);
+    setFailedList([]);
   }
 
   return (
@@ -77,6 +84,30 @@ const AddCSVModal = ({ open, toggleAddCSVModalOpen, finishCSVForm , getEnrollmen
     <LoadingOverlay loading={loading}/>
     <Modal open={open} title="Add a User With CSV file" footer={null} onCancel={handleCancel}>
       <Form layout="vertical" onFinish={handleFinish}>
+        <p style={{ marginBottom: 8, color: "#595959" }}>
+          Upload a CSV with a header row. The <b>Email</b> column is required.
+          Optionally include <b>Name</b>, <b>EID</b>, and <b>Role</b> columns.
+        </p>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12, fontFamily: "monospace", marginBottom: 16 }}>
+          <thead>
+            <tr style={{ background: "#e8e8e8" }}>
+              {["Name", "Email", "EID", "Role"].map(col => (
+                <th key={col} style={{ border: "1px solid #d9d9d9", padding: "4px 8px", textAlign: "left", fontWeight: 600 }}>
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ background: "#fafafa" }}>
+              {["Jane Doe", "jdoe@university.edu", "12345678", "student"].map((val, i) => (
+                <td key={i} style={{ border: "1px solid #d9d9d9", padding: "4px 8px" }}>
+                  {val}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
         <Form.Item label={`Upload File (${maxMB}MB limit)`} name = "file">
           <Upload.Dragger
             name="file"
@@ -97,6 +128,20 @@ const AddCSVModal = ({ open, toggleAddCSVModalOpen, finishCSVForm , getEnrollmen
             <p className="ant-upload-text">Click or drag file here to upload CSV File</p>
           </Upload.Dragger>
         </Form.Item>
+        {failedList.length > 0 && (
+          <div style={{ marginBottom: 16, background: "#fff2f0", border: "1px solid #ffccc7", borderRadius: 4, padding: "8px 12px" }}>
+            <p style={{ marginBottom: 6, fontWeight: 600, color: "#cf1322" }}>
+              {failedList.length} email(s) could not be enrolled:
+            </p>
+            <ul style={{ margin: 0, paddingLeft: 18 }}>
+              {failedList.map((f, i) => (
+                <li key={i} style={{ fontSize: 13, color: "#434343" }}>
+                  <b>{f.email}</b> — {f.reason}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         <Form.Item>
           <Space>
             <Button type="primary" htmlType="submit">

--- a/frontend/src/pages/instructor/enrollment/index.js
+++ b/frontend/src/pages/instructor/enrollment/index.js
@@ -109,14 +109,7 @@ export default () => {
       formData.append("course_id", courseId);
 
       return createEnrollmentCSV(formData)
-        .then((res) => {
-          if (res.status !== 200) {
-            return res.data.then((error) => {
-              throw new Error(error.error || "Something went wrong");
-            });
-          }
-          return res.data;
-        })
+        .then((res) => res.data)
   }, [courseId]);
   
   const finishMoreUsers = useCallback(


### PR DESCRIPTION
## Summary

- The CSV enrollment button was broken — it read raw text values from the first column and tried to insert them directly as database UUIDs, causing Postgres errors while the frontend always showed success
- Backend now looks students up by email address (supports both \"Email\" and \"Email Address\" column headers, in any column order)
- Distinguishes between \"User not found\" and \"Already enrolled\" failure reasons
- Frontend modal stays open on partial failure and displays a clear per-email failure list with reasons, only closes on full success
- Added a spreadsheet-style CSV format guide inside the modal so instructors know what to upload
- Closes #319 

## Files Changed

- `backend/routes/course.py`
- `frontend/src/pages/instructor/enrollment/AddCSVModal.js`
- `frontend/src/pages/instructor/enrollment/index.js`
- `backend/test/unit/test_course.py`

## CSV Format

The expected CSV format is now:

| Name | Email | EID | Role |
|------|-------|-----|------|
| Jane Doe | jdoe@university.edu | 12345678 | student |

Only the **Email** column is required.



https://github.com/user-attachments/assets/a30d8041-cec5-45e4-9b88-559b8bdc350a



## Test Plan

- [x] Upload a valid CSV with existing student emails — all should enroll and modal closes
- [x] Upload a CSV where some emails don't exist in the system — modal stays open showing \"User not found\" for each
- [x] Upload a CSV where students are already enrolled — modal stays open showing \"Already enrolled\"
- [x] Upload a CSV with no Email header — should return a 400 error
- [x] Verify all 138 backend tests pass with `make test`