### PR TITLE
Fix stray </Card> in CreateAssignment breaking JSX structure

### DIFF
--- a/frontend/src/pages/instructor/assignments/CreateAssignment.js
+++ b/frontend/src/pages/instructor/assignments/CreateAssignment.js
@@ -628,7 +628,6 @@ export default ({
                           </Form.Item>
                         </>
                       )}
-                    </Card>
 
                     <Form.Item
                       label="CONFIGURE AUTOGRADER"


### PR DESCRIPTION
## Summary
- Removes a stray `</Card>` closing tag in `CreateAssignment.js` that had no matching opening tag
- This caused 12+ cascading JSX parse errors, breaking the entire Create Assignment page

## Root Cause
PR #302 (`feature/code-editor-ai-feedback`) removed the `<Card title="AI Feedback Settings">` wrapper around the AI feedback section but left its closing `</Card>` behind, likely during one of the multiple merge conflict resolutions on that branch.

## Test plan
- [x] Verify the Create Assignment page loads without errors
- [x] Confirm AI feedback settings section still renders correctly
- [x] Check no other JSX structure is affected