### PR TITLE
Use backend env file in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
             context: "./backend/"
             dockerfile: Dockerfile
         env_file:
-            - ./.env
+            - ./backend/.env
         environment:
             FLASK_APP: app.py
             FLASK_DEBUG: 1


### PR DESCRIPTION
updates Docker Compose to read the backend environment file from:
env_file:
./backend/.env
Expected result:
Docker Compose should no longer ask for a root .env file.
The backend container should start using values from backend/.env.