### PR TITLE
fix: allow students to edit submission filename in code editor (#335)

### DIFF
--- a/frontend/src/components/CodeEditor.js
+++ b/frontend/src/components/CodeEditor.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
-import { Button, Space, Tag, Tooltip } from "antd";
+import { Button, Input, Space, Tag, Tooltip } from "antd";
 import {
   SaveOutlined,
   PlayCircleOutlined,
@@ -9,6 +9,7 @@ import {
   CheckCircleFilled,
   ClockCircleOutlined,
   CaretRightOutlined,
+  EditOutlined,
 } from "@ant-design/icons";
 
 // CodeMirror 6 imports
@@ -105,6 +106,7 @@ const oneDarkTheme = EditorView.theme({
  *   onOpenHistory   – () => void
  *   autoSaveStatus  – 'idle' | 'saving' | 'saved' | 'error'
  *   fileName        – string
+ *   onFileNameChange – (newFileName) => void
  *   language        – string (e.g. "python")
  *   readOnly        – boolean
  */
@@ -118,6 +120,7 @@ export default function CodeEditor({
   onOpenHistory,
   autoSaveStatus = "idle",
   fileName = "solution.py",
+  onFileNameChange,
   language = "python",
   readOnly = false,
 }) {
@@ -128,6 +131,8 @@ export default function CodeEditor({
   const [cursorLine, setCursorLine] = useState(1);
   const [lineCount, setLineCount] = useState(1);
   const [charCount, setCharCount] = useState(0);
+  const [editingFileName, setEditingFileName] = useState(false);
+  const [fileNameInput, setFileNameInput] = useState(fileName);
 
   // Keep refs up to date
   onChangeRef.current = onChange;
@@ -272,7 +277,42 @@ export default function CodeEditor({
         <div style={styles.toolbarLeft}>
           <Space size="small">
             <CodeOutlined style={{ color: "#1890ff" }} />
-            <span style={styles.fileName}>{fileName}</span>
+            {editingFileName ? (
+              <Input
+                size="small"
+                value={fileNameInput}
+                onChange={(e) => setFileNameInput(e.target.value)}
+                onPressEnter={() => {
+                  const trimmed = fileNameInput.trim();
+                  if (trimmed && onFileNameChange) {
+                    onFileNameChange(trimmed);
+                  }
+                  setEditingFileName(false);
+                }}
+                onBlur={() => {
+                  const trimmed = fileNameInput.trim();
+                  if (trimmed && onFileNameChange) {
+                    onFileNameChange(trimmed);
+                  }
+                  setEditingFileName(false);
+                }}
+                style={{ width: 200, fontFamily: 'monospace', fontSize: 13 }}
+                autoFocus
+              />
+            ) : (
+              <Tooltip title="Click to edit filename (important for autograder)">
+                <span
+                  style={{ ...styles.fileName, cursor: 'pointer' }}
+                  onClick={() => {
+                    setFileNameInput(fileName);
+                    setEditingFileName(true);
+                  }}
+                >
+                  {fileName}
+                  <EditOutlined style={{ marginLeft: 4, fontSize: 11, color: '#636d83' }} />
+                </span>
+              </Tooltip>
+            )}
             <Tag color="blue" style={{ marginLeft: 4 }}>
               {language.toUpperCase()}
             </Tag>

--- a/frontend/src/pages/codeEditor/index.js
+++ b/frontend/src/pages/codeEditor/index.js
@@ -120,11 +120,12 @@ export default function CodeEditorPage() {
 
       setAutoSaveStatus("saving");
       try {
+        const currentFileName = fileNameRef.current;
         const res = await saveCodeDraft({
           student_id: userInfo.id,
           assignment_id: assignmentId,
           content: code,
-          file_name: fileName,
+          file_name: currentFileName,
           auto_saved: isAuto,
         });
 
@@ -139,7 +140,7 @@ export default function CodeEditorPage() {
         setAutoSaveStatus("error");
       }
     },
-    [code, userInfo?.id, assignmentId, fileName]
+    [code, userInfo?.id, assignmentId]
   );
 
   // Ref to hold latest saveDraft for use in intervals/handlers
@@ -149,6 +150,8 @@ export default function CodeEditorPage() {
   // Auto-save: save every 30 seconds if code has changed
   const codeRef = useRef(code);
   codeRef.current = code;
+  const fileNameRef = useRef(fileName);
+  fileNameRef.current = fileName;
   const autoSaveStatusRef = useRef(autoSaveStatus);
   autoSaveStatusRef.current = autoSaveStatus;
 
@@ -319,6 +322,10 @@ export default function CodeEditorPage() {
             onOpenHistory={() => setHistoryOpen(true)}
             autoSaveStatus={autoSaveStatus}
             fileName={fileName}
+            onFileNameChange={(name) => {
+              setFileName(name);
+              saveDraftRef.current(false);
+            }}
             language="python"
             readOnly={submitting}
           />


### PR DESCRIPTION
## Issue

Fixes #335: When Editor Submission is used by the Student, the autograder cannot find the submission because the file is named after the assignment name, not the name the autograder expects.

## Problem

The code editor hardcoded the filename from the assignment name (e.g., `spiral_assignment.py`), but the autograder expects a specific filename (e.g., `spiral.py`). Students had no way to change the filename, causing autograder failures.

## Changes

### `frontend/src/components/CodeEditor.js`

- Added editable filename input in the CodeEditor toolbar with click-to-edit UX
- Added `onFileNameChange` prop to CodeEditor component
- Added `EditOutlined` icon import and `Input` component import from antd
- When clicked, the filename becomes an editable input field; pressing Enter or blurring saves the change
- Added tooltip explaining filename importance for autograder compatibility

### `frontend/src/pages/codeEditor/index.js`

- Added `onFileNameChange` handler that updates filename state and saves the draft
- Fixed stale filename bug in `saveDraft` by using `fileNameRef` instead of closure variable
- Ensured filename changes are persisted immediately so the correct filename is used on submission

## How to Test

1. Open an assignment with code editor enabled
2. Notice the filename displayed in the editor toolbar (e.g., "spiral_assignment.py")
3. Click the filename — it becomes an editable input field
4. Change the filename to match the autograder's expected name (e.g., "spiral.py")
5. Press Enter or click outside — the filename is saved
6. Submit the assignment — the autograder should now find the correct filename
