### PR TITLE
fix: allow students to resubmit via code editor after submission (#336)

### DIFF
--- a/frontend/src/pages/result/ActionButtons.js
+++ b/frontend/src/pages/result/ActionButtons.js
@@ -1,7 +1,7 @@
 import { Button, Space } from "antd";
-import { ReloadOutlined, UploadOutlined, DownloadOutlined, ClockCircleOutlined } from "@ant-design/icons";
+import { ReloadOutlined, UploadOutlined, DownloadOutlined, ClockCircleOutlined, CodeOutlined } from "@ant-design/icons";
 
-export default function ActionButtons({ onRerun, onUpload, onDownload, onHistoryOpen, isStudent }) {
+export default function ActionButtons({ onRerun, onUpload, onResubmitEditor, onDownload, onHistoryOpen, isStudent, enableCodeEditor }) {
   return (
     <Space>
       <Button icon={<ReloadOutlined />} onClick={onRerun}>Rerun Autograder</Button>
@@ -10,10 +10,16 @@ export default function ActionButtons({ onRerun, onUpload, onDownload, onHistory
       )}
       <Button icon={<ClockCircleOutlined />} onClick={onHistoryOpen}>Submission History</Button>
       <Button icon={<DownloadOutlined />} onClick={onDownload}>Download Submission</Button>
-      <Button onClick={onUpload}>
-        Resubmit
-        <UploadOutlined />
-      </Button>
+      {enableCodeEditor ? (
+        <Button type="primary" icon={<CodeOutlined />} onClick={onResubmitEditor}>
+          Resubmit via Editor
+        </Button>
+      ) : (
+        <Button onClick={onUpload}>
+          Resubmit
+          <UploadOutlined />
+        </Button>
+      )}
     </Space>
   );
 }

--- a/frontend/src/pages/result/index.js
+++ b/frontend/src/pages/result/index.js
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback, useEffect, useState } from "react";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { Card, PageHeader, Radio, message } from "antd";
 
 import { GlobalContext } from "../../App";
@@ -28,6 +28,7 @@ export default function AssignmentResult() {
   const [studentId, setStudentId] = useState("");
   // const { assignmentId, studentId } = useParams();
   const location = useLocation();
+  const navigate = useNavigate();
   // adding global context variable
   const { userInfo, assignmentInfo, updateAssignmentInfo } =
     useContext(GlobalContext);
@@ -38,6 +39,8 @@ export default function AssignmentResult() {
 
   // used to check if AI Feedback has been enabled on this assignment
   const [aiFeedbackEnabled, setAiFeedbackEnabled] = useState(true);
+  // used to check if code editor is enabled for this assignment
+  const [enableCodeEditor, setEnableCodeEditor] = useState(false);
   
   useEffect(() => {
     // Fetching student and assignment IDs based on this submission ID
@@ -125,6 +128,7 @@ export default function AssignmentResult() {
           setLateAllowed(res.data.late_submission);
           setLateDueDate(moment(res.data.late_due_date).valueOf());
           setAiFeedbackEnabled(res.data.ai_feedback_enabled);
+          setEnableCodeEditor(!!res.data.enable_code_editor);
           if (extension?.data.due_date_extension) {
             setDueDate(moment(extension.data.due_date_extension).valueOf());
           }
@@ -264,9 +268,21 @@ export default function AssignmentResult() {
           <ActionButtons
             onRerun={() => {}} // Implement or replace with actual function
             onUpload={() => toggleModal("upload")}
+            onResubmitEditor={() => {
+              const now = moment();
+              const due = dueDate ? moment(dueDate) : null;
+              const late = lateDueDate ? moment(lateDueDate) : null;
+              const canSubmit = (!due || !now.isAfter(due)) || (late && lateAllowed && !now.isAfter(late));
+              if (!canSubmit) {
+                message.error("Due Date Has Passed");
+                return;
+              }
+              navigate(`/codeEditor/${assignmentId}`);
+            }}
             onDownload={handleDownload} // Implement or replace with actual function
             onHistoryOpen={() => toggleModal("history")}
             isStudent={userInfo?.isStudent}
+            enableCodeEditor={enableCodeEditor}
           />
         </PageBottom>
       ) : (


### PR DESCRIPTION
## Issue
Fixes #336: When Editor Submission is used, there is no way for students to resubmit!

## Problem
After submitting via the code editor, students were taken to the results page with no way to go back to the editor and resubmit. The existing 'Resubmit' button only opened the file upload modal, not the code editor.

## Changes

**frontend/src/pages/result/ActionButtons.js:**
- Added CodeOutlined icon import
- Added onResubmitEditor and enableCodeEditor props
- When enableCodeEditor is true, shows 'Resubmit via Editor' button instead of the file upload resubmit

**frontend/src/pages/result/index.js:**
- Added useNavigate import
- Added enableCodeEditor state variable
- Fetches enable_code_editor from assignment details
- Passes onResubmitEditor handler that checks due dates before navigating to /codeEditor/:assignmentId
- Passes enableCodeEditor to ActionButtons

## How It Works
When the assignment has code editor enabled, the results page now shows a 'Resubmit via Editor' button instead of the file upload resubmit button. Clicking it navigates the student back to the code editor with their previous code and draft loaded, allowing them to make changes and resubmit.