### PR TITLE
Review Grades: add CSV grade download

### DIFF
--- a/backend/routes/submission.py
+++ b/backend/routes/submission.py
@@ -2,6 +2,7 @@ import uuid
 import json
 import sys
 import io
+import csv
 import tarfile
 import subprocess
 import os
@@ -544,6 +545,52 @@ def get_all_assignment_submissions():
     submissions_data = submissions_schema.dump(all_submissions)
 
     return jsonify(submissions_data), 200
+
+@submission.route('/export_grades_csv', methods=["GET"])
+def export_grades_csv():
+    assignment_id = request.args.get("assignment_id")
+
+    if not assignment_id:
+        raise BadRequestError("Missing assignment_id")
+
+    # Security: Verify the requester is course staff or admin
+    session_user_id = _verify_course_staff(assignment_id)
+
+    assignment = db.session.query(Assignment).filter_by(id=assignment_id).first()
+    if not assignment:
+        raise NotFoundError("Assignment not found")
+
+    all_submissions = Submission.query.filter_by(assignment_id=assignment_id).all()
+    subs_by_student = {}
+    for sub in all_submissions:
+        subs_by_student.setdefault(sub.student_id, []).append(sub)
+
+    enrolled_users = db.session.query(User).join(
+        Enrollment, Enrollment.student_id == User.id
+    ).filter(Enrollment.course_id == assignment.course_id).all()
+    # Matches the frontend's row set: everyone enrolled except the viewer.
+    students = [u for u in enrolled_users if u.id != session_user_id]
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["First & Last Name", "Email", "Score", "Graded", "Submitted At (UTC)"])
+
+    for student in students:
+        active_sub = next((s for s in subs_by_student.get(student.id, []) if s.active), None)
+        writer.writerow([
+            student.name,
+            student.email_address,
+            active_sub.score if active_sub and active_sub.score is not None else "",
+            "Yes" if active_sub else "No",
+            active_sub.submitted_at.isoformat() if active_sub and active_sub.submitted_at else "",
+        ])
+
+    filename = secure_filename(f"{assignment.name}_grades.csv")
+    return current_app.response_class(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
 
 @submission.route('/delete_submission', methods=["DELETE"])
 def delete_submission():

--- a/frontend/src/pages/result/index.js
+++ b/frontend/src/pages/result/index.js
@@ -50,7 +50,8 @@ export default function AssignmentResult() {
       console.log("Fetching IDs based on submission ID:", submissionId);
       try {
         const details = await fetch(
-          `${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${submissionId}`
+          `${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${submissionId}`,
+          { credentials: "include" }
         );
         const data = await details.json();
         if (data) {
@@ -88,7 +89,8 @@ export default function AssignmentResult() {
     const interval = setInterval(async () => {
       try {
         const response = await fetch(
-          `${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${toSend.id}`
+          `${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${toSend.id}`,
+          { credentials: "include" }
         );
         const updated = await response.json();
         if (updated?.ai_feedback) {
@@ -156,7 +158,8 @@ export default function AssignmentResult() {
     const fetchStudentName = async () => {
       try {
         const response = await fetch(
-          `${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${submissionId}`
+          `${process.env.REACT_APP_API_URL}/get_submission_details?submission_id=${submissionId}`,
+          { credentials: "include" }
         );
         const studentData = await response.json();
         if (studentData) {

--- a/frontend/src/pages/reviewGrades/index.js
+++ b/frontend/src/pages/reviewGrades/index.js
@@ -136,7 +136,8 @@ export default () => {
       try {
         // First get all submissions
         const allSubmissions = await fetch(
-          `${process.env.REACT_APP_API_URL}/get_all_assignment_submissions?assignment_id=${assignmentId}`
+          `${process.env.REACT_APP_API_URL}/get_all_assignment_submissions?assignment_id=${assignmentId}`,
+          { credentials: "include" }
         );
         if (!allSubmissions.ok) {
           throw new Error("Failed to load all submissions.");
@@ -145,7 +146,8 @@ export default () => {
 
         // Now fetch all the students
         const students = await fetch(
-          `${process.env.REACT_APP_API_URL}/get_course_enrollment?course_id=${courseInfo.id}`
+          `${process.env.REACT_APP_API_URL}/get_course_enrollment?course_id=${courseInfo.id}`,
+          { credentials: "include" }
         );
         if (!students.ok) {
           throw new Error("Failed to load students list.");

--- a/frontend/src/pages/reviewGrades/index.js
+++ b/frontend/src/pages/reviewGrades/index.js
@@ -34,7 +34,30 @@ export default () => {
   const goAssignmentResult = (submissionId) => {
     navigate(`/assignmentResult/${submissionId}`);
   };
-  
+
+  const handleDownloadGrades = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `${process.env.REACT_APP_API_URL}/export_grades_csv?assignment_id=${assignmentId}`,
+        { credentials: "include" }
+      );
+      if (!res.ok) {
+        throw new Error("Failed to download grades.");
+      }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${assignmentInfo?.name || "assignment"}_grades.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Error downloading grades:", err);
+    }
+  }, [assignmentId, assignmentInfo]);
+
   const columns = [
     {
       title: "FIRST & LAST NAME",
@@ -208,7 +231,7 @@ export default () => {
       </PageContent>
       <PageBottom>
         <Space>
-          <Button icon={<DownloadOutlined />} >
+          <Button icon={<DownloadOutlined />} onClick={handleDownloadGrades}>
             Download Grades
           </Button>
           <Button icon={<DownloadOutlined />} >


### PR DESCRIPTION
## Summary
- Wires up the previously inert "Download Grades" button on the instructor Review Grades page.
- Adds `GET /export_grades_csv?assignment_id=` (backend), mirroring the auth/query pattern of the existing `get_all_assignment_submissions` endpoint (instructor/TA/admin only).
- Frontend fetches the CSV and triggers a browser download.

Part of #243 (one of 5 PRs splitting that issue's feature list; see #243 for the full breakdown).

## Test plan
- [x] Run backend test suite for submission routes
- [x] As instructor/TA, open a Review Grades page, click "Download Grades", confirm CSV downloads with rows matching the on-screen table
- [x] Confirm a student (non-staff) request to the endpoint is rejected